### PR TITLE
Fixed build on the MSVC 2015

### DIFF
--- a/gme/Ay_Emu.cpp
+++ b/gme/Ay_Emu.cpp
@@ -128,8 +128,8 @@ extern gme_type_t const gme_ay_type = &gme_ay_type_;
 
 blargg_err_t Ay_Emu::load_mem_( byte const* in, long size )
 {
-	static_assert( offsetof (header_t,track_info [2]) == header_size, "AY Header layout incorrect!" );
-	
+	blaarg_static_assert( offsetof (header_t,track_info [2]) == header_size, "AY Header layout incorrect!" );
+
 	RETURN_ERR( parse_header( in, size, &file ) );
 	set_track_count( file.header->max_track + 1 );
 	

--- a/gme/Classic_Emu.cpp
+++ b/gme/Classic_Emu.cpp
@@ -25,9 +25,9 @@ Classic_Emu::Classic_Emu()
 	voice_types   = 0;
 	
 	// avoid inconsistency in our duplicated constants
-	static_assert( (int) wave_type  == (int) Multi_Buffer::wave_type, "wave_type inconsistent across two classes using it" );
-	static_assert( (int) noise_type == (int) Multi_Buffer::noise_type, "noise_type inconsistent across two classes using it"  );
-	static_assert( (int) mixed_type == (int) Multi_Buffer::mixed_type, "mixed_type inconsistent across two classes using it"  );
+	blaarg_static_assert( (int) wave_type  == (int) Multi_Buffer::wave_type, "wave_type inconsistent across two classes using it" );
+	blaarg_static_assert( (int) noise_type == (int) Multi_Buffer::noise_type, "noise_type inconsistent across two classes using it"  );
+	blaarg_static_assert( (int) mixed_type == (int) Multi_Buffer::mixed_type, "mixed_type inconsistent across two classes using it"  );
 }
 
 Classic_Emu::~Classic_Emu()

--- a/gme/Effects_Buffer.cpp
+++ b/gme/Effects_Buffer.cpp
@@ -217,7 +217,7 @@ void Effects_Buffer::config( const config_t& cfg )
 			chan_types [i*chan_types_count+2].left   = &bufs [i*max_buf_count+5];
 			chan_types [i*chan_types_count+2].right  = &bufs [i*max_buf_count+6];
 		}
-		static_assert( chan_types_count >= 3, "Need at least three audio channels for effects processing" );
+		blaarg_static_assert( chan_types_count >= 3, "Need at least three audio channels for effects processing" );
 	}
 	else
 	{

--- a/gme/Gbs_Emu.cpp
+++ b/gme/Gbs_Emu.cpp
@@ -107,7 +107,7 @@ extern gme_type_t const gme_gbs_type = &gme_gbs_type_;
 
 blargg_err_t Gbs_Emu::load_( Data_Reader& in )
 {
-	static_assert( offsetof (header_t,copyright [32]) == header_size, "GBS Header layout incorrect!" );
+	blaarg_static_assert( offsetof (header_t,copyright [32]) == header_size, "GBS Header layout incorrect!" );
 	RETURN_ERR( rom.load( in, header_size, &header_, 0 ) );
 	
 	set_track_count( header_.track_count );

--- a/gme/Gym_Emu.cpp
+++ b/gme/Gym_Emu.cpp
@@ -210,7 +210,7 @@ void Gym_Emu::mute_voices_( int mask )
 
 blargg_err_t Gym_Emu::load_mem_( byte const* in, long size )
 {
-	static_assert( offsetof (header_t,packed [4]) == header_size, "GYM Header layout incorrect!" );
+	blaarg_static_assert( offsetof (header_t,packed [4]) == header_size, "GYM Header layout incorrect!" );
 	int offset = 0;
 	RETURN_ERR( check_header( in, size, &offset ) );
 	set_voice_count( 8 );

--- a/gme/Hes_Emu.cpp
+++ b/gme/Hes_Emu.cpp
@@ -119,7 +119,7 @@ struct Hes_File : Gme_Info_
 	
 	blargg_err_t load_( Data_Reader& in )
 	{
-		static_assert( offsetof (header_t,fields) == Hes_Emu::header_size + 0x20, "HES header layout is incorrect!" );
+		blaarg_static_assert( offsetof (header_t,fields) == Hes_Emu::header_size + 0x20, "HES header layout is incorrect!" );
 		blargg_err_t err = in.read( &h, sizeof h );
 		if ( err )
 			return (err == in.eof_error ? gme_wrong_file_type : err);
@@ -144,7 +144,7 @@ extern gme_type_t const gme_hes_type = &gme_hes_type_;
 
 blargg_err_t Hes_Emu::load_( Data_Reader& in )
 {
-	static_assert( offsetof (header_t,unused [4]) == header_size, "HES header layout is incorrect!" );
+	blaarg_static_assert( offsetof (header_t,unused [4]) == header_size, "HES header layout is incorrect!" );
 	RETURN_ERR( rom.load( in, header_size, &header_, unmapped ) );
 	
 	RETURN_ERR( check_hes_header( header_.tag ) );

--- a/gme/Kss_Emu.cpp
+++ b/gme/Kss_Emu.cpp
@@ -125,8 +125,8 @@ void Kss_Emu::update_gain()
 blargg_err_t Kss_Emu::load_( Data_Reader& in )
 {
 	memset( &header_, 0, sizeof header_ );
-	static_assert( offsetof (header_t,device_flags) == header_size - 1, "KSS Header layout incorrect!" );
-	static_assert( offsetof (ext_header_t,msx_audio_vol) == ext_header_size - 1, "KSS Extended Header layout incorrect!" );
+	blaarg_static_assert( offsetof (header_t,device_flags) == header_size - 1, "KSS Header layout incorrect!" );
+	blaarg_static_assert( offsetof (ext_header_t,msx_audio_vol) == ext_header_size - 1, "KSS Extended Header layout incorrect!" );
 	RETURN_ERR( rom.load( in, header_size, STATIC_CAST(header_t*,&header_), 0 ) );
 	
 	RETURN_ERR( check_kss_header( header_.tag ) );

--- a/gme/Nes_Cpu.cpp
+++ b/gme/Nes_Cpu.cpp
@@ -78,7 +78,7 @@ void Nes_Cpu::reset( void const* unmapped_page )
 	end_time_ = future_nes_time;
 	error_count_ = 0;
 	
-	static_assert( page_size == 0x800, "NES set to use unhandled page size" ); // assumes this
+	blaarg_static_assert( page_size == 0x800, "NES set to use unhandled page size" ); // assumes this
 	set_code_page( page_count, unmapped_page );
 	map_code( 0x2000, 0xE000, unmapped_page, true );
 	map_code( 0x0000, 0x2000, low_mem, true );

--- a/gme/Nes_Vrc6_Apu.cpp
+++ b/gme/Nes_Vrc6_Apu.cpp
@@ -72,7 +72,7 @@ void Nes_Vrc6_Apu::end_frame( blip_time_t time )
 
 void Nes_Vrc6_Apu::save_state( vrc6_apu_state_t* out ) const
 {
-	static_assert( sizeof (vrc6_apu_state_t) == 20, "VRC APU State layout incorrect!" );
+	blaarg_static_assert( sizeof (vrc6_apu_state_t) == 20, "VRC APU State layout incorrect!" );
 	out->saw_amp = oscs [2].amp;
 	for ( int i = 0; i < osc_count; i++ )
 	{

--- a/gme/Nsf_Emu.cpp
+++ b/gme/Nsf_Emu.cpp
@@ -330,7 +330,7 @@ blargg_err_t Nsf_Emu::init_sound()
 
 blargg_err_t Nsf_Emu::load_( Data_Reader& in )
 {
-	static_assert( offsetof (header_t,unused [4]) == header_size, "NSF Header layout incorrect!" );
+	blaarg_static_assert( offsetof (header_t,unused [4]) == header_size, "NSF Header layout incorrect!" );
 	RETURN_ERR( rom.load( in, header_size, &header_, 0 ) );
 
 	set_track_count( header_.track_count );

--- a/gme/Nsfe_Emu.cpp
+++ b/gme/Nsfe_Emu.cpp
@@ -96,7 +96,7 @@ struct nsfe_info_t
 blargg_err_t Nsfe_Info::load( Data_Reader& in, Nsf_Emu* nsf_emu )
 {
 	int const nsfe_info_size = 16;
-	static_assert( offsetof (nsfe_info_t,unused [6]) == nsfe_info_size, "NSFE Info header layout incorrect!" );
+	blaarg_static_assert( offsetof (nsfe_info_t,unused [6]) == nsfe_info_size, "NSFE Info header layout incorrect!" );
 	
 	// check header
 	byte signature [4];

--- a/gme/Snes_Spc.cpp
+++ b/gme/Snes_Spc.cpp
@@ -217,7 +217,7 @@ blargg_err_t Snes_Spc::load_spc( void const* data, long size )
 	spc_file_t const* const spc = (spc_file_t const*) data;
 	
 	// be sure compiler didn't insert any padding into fle_t
-	static_assert( sizeof (spc_file_t) == spc_min_file_size + 0x80, "SPC File header layout incorrect!" );
+	blaarg_static_assert( sizeof (spc_file_t) == spc_min_file_size + 0x80, "SPC File header layout incorrect!" );
 	
 	// Check signature and file size
 	if ( size < signature_size || memcmp( spc, signature, 27 ) )

--- a/gme/Spc_Dsp.cpp
+++ b/gme/Spc_Dsp.cpp
@@ -668,10 +668,10 @@ void Spc_Dsp::init( void* ram_64k )
 	reset();
 	
 	// be sure this sign-extends
-	static_assert( (int16_t) 0x8000 == -0x8000, "This compiler doesn't sign-extend during integer promotion" );
+	blaarg_static_assert( (int16_t) 0x8000 == -0x8000, "This compiler doesn't sign-extend during integer promotion" );
 
 	// be sure right shift preserves sign
-	static_assert( (-1 >> 1) == -1, "This compiler doesn't preserve sign on right-shift" );
+	blaarg_static_assert( (-1 >> 1) == -1, "This compiler doesn't preserve sign on right-shift" );
 		
 	#ifndef NDEBUG
 		// check clamp macro

--- a/gme/Spc_Emu.cpp
+++ b/gme/Spc_Emu.cpp
@@ -416,7 +416,7 @@ void Spc_Emu::disable_echo_( bool disable )
 
 blargg_err_t Spc_Emu::load_mem_( byte const* in, long size )
 {
-	static_assert( offsetof (header_t,unused2 [46]) == header_size, "SPC Header layout incorrect!" );
+	blaarg_static_assert( offsetof (header_t,unused2 [46]) == header_size, "SPC Header layout incorrect!" );
 	file_data = in;
 	file_size = size;
 	set_voice_count( Snes_Spc::voice_count );

--- a/gme/Vgm_Emu.cpp
+++ b/gme/Vgm_Emu.cpp
@@ -324,8 +324,8 @@ void Vgm_Emu::mute_voices_( int mask )
 
 blargg_err_t Vgm_Emu::load_mem_( byte const* new_data, long new_size )
 {
-	static_assert( offsetof (header_t,unused2 [8]) == header_size, "VGM Header layout incorrect!" );
-	
+	blaarg_static_assert( offsetof (header_t,unused2 [8]) == header_size, "VGM Header layout incorrect!" );
+
 	if ( new_size <= header_size )
 		return gme_wrong_file_type;
 	

--- a/gme/blargg_common.h
+++ b/gme/blargg_common.h
@@ -27,6 +27,12 @@
 	#define STATIC_CAST(T,expr) ((T) (expr))
 #endif
 
+#if !defined(_MSC_VER) || _MSC_VER > 1910
+	#define blaarg_static_assert(cond, msg) static_assert(cond, msg)
+#else
+	#define blaarg_static_assert(cond, msg) assert(cond)
+#endif
+
 // blargg_err_t (0 on success, otherwise error string)
 #ifndef blargg_err_t
 	typedef const char* blargg_err_t;


### PR DESCRIPTION
The `static_assert()` breaks the build on the MSVC 2015, so, use a condition to use the static_assert at newer MSVC only, and stay with the regular assert on the older MSVC versions.

Original: https://bitbucket.org/mpyne/game-music-emu/pull-requests/38