### PR TITLE
Effects_Buffer: Offset samples by frame size for multi-channel buffering

### DIFF
--- a/gme/Effects_Buffer.cpp
+++ b/gme/Effects_Buffer.cpp
@@ -383,11 +383,11 @@ void Effects_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
 		
 		if ( (int16_t) cs0 != cs0 )
 			cs0 = 0x7FFF - (cs0 >> 24);
-		((uint32_t*) out) [i*2+0] = ((uint16_t) cs0) | (uint16_t(cs0) << 16);
+		((uint32_t*) out) [i] = ((uint16_t) cs0) | (uint16_t(cs0) << 16);
 		
 		if ( (int16_t) cs1 != cs1 )
 			cs1 = 0x7FFF - (cs1 >> 24);
-		((uint32_t*) out) [i*2+1] = ((uint16_t) cs1) | (uint16_t(cs1) << 16);
+		((uint32_t*) out) [i+max_voices] = ((uint16_t) cs1) | (uint16_t(cs1) << 16);
 		out += max_voices*4;
 	}
 	

--- a/gme/Effects_Buffer.cpp
+++ b/gme/Effects_Buffer.cpp
@@ -395,14 +395,10 @@ void Effects_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
 	{
 		int s = BLIP_READER_READ( c );
 		BLIP_READER_NEXT( c, bass );
+		if ( (int16_t) s != s )
+			s = 0x7FFF - (s >> 24);
 		out [i*2+0] = s;
 		out [i*2+1] = s;
-		if ( (int16_t) s != s )
-		{
-			s = 0x7FFF - (s >> 24);
-			out [i*2+0] = s;
-			out [i*2+1] = s;
-		}
 	}
 	
 	BLIP_READER_END( c, bufs [i*max_buf_count+0] );


### PR DESCRIPTION
If we request more than 1 frame of multi-channel audio, the buffer will use a method that involves buffering 2 samples at a time for each voice, The placement of these samples, however, is incorrect.

Each frame should consist of 1 sample per voice (we actually duplicate the sample for the sake of stereo upmixing, so if `max_voices` equals 8, the frame will consist of 16 samples in total).

Rather than placing the voice's samples right next to each other, we should instead give the sample(s) for the 2nd frame an offset of `max_voices` (times 2 for upmixing), in order to account for the rest of the voices that the full frame will consist of. If we don't do this, the two frames will become interlaced.

Reasons why this has gone unnoticed:
- Multi-channel audio is a niche feature that hardly anyone uses.
- In most cases, only 1 frame per request is needed.
- Even with every 2 frames interlaced, it's not immediately obvious that anything is wrong with the audio, particularly 8-bit audio, unless it is either closely inspected or upsampled.