### PR TITLE
WIP: Improved handling of RSN files

### DIFF
--- a/gme/Gme_File.cpp
+++ b/gme/Gme_File.cpp
@@ -98,6 +98,8 @@ blargg_err_t Gme_File::load( Data_Reader& in )
 
 blargg_err_t Gme_File::load_file( const char* path )
 {
+	if ( is_archive )
+		return load_archive( path );
 	pre_load();
 	GME_FILE_READER in;
 	RETURN_ERR( in.open( path ) );

--- a/gme/Gme_File.cpp
+++ b/gme/Gme_File.cpp
@@ -106,6 +106,12 @@ blargg_err_t Gme_File::load_file( const char* path )
 	return post_load( load_( in ) );
 }
 
+blargg_err_t Gme_File::load_archive( const char* path )
+{
+	pre_load();
+	return post_load( load_archive_( path ) );
+}
+
 blargg_err_t Gme_File::load_remaining_( void const* h, long s, Data_Reader& in )
 {
 	Remaining_Reader rem( h, s, &in );

--- a/gme/Gme_File.h
+++ b/gme/Gme_File.h
@@ -113,7 +113,7 @@ public:
 	void set_user_cleanup( gme_user_cleanup_t func ) { user_cleanup_ = func; }
 
 	bool is_archive = false;
-	virtual blargg_err_t load_archive( const char* ) { return gme_wrong_file_type; }
+	blargg_err_t load_archive( const char* );
 
 public:
 	// deprecated
@@ -134,6 +134,7 @@ protected:
 	virtual void unload();  // called before loading file and if loading fails
 	virtual blargg_err_t load_( Data_Reader& ); // default loads then calls load_mem_()
 	virtual blargg_err_t load_mem_( byte const* data, long size ); // use data in memory
+	virtual blargg_err_t load_archive_( const char* ) { return gme_wrong_file_type; }
 	virtual blargg_err_t track_info_( track_info_t* out, int track ) const = 0;
 	virtual void pre_load();
 	virtual void post_load_();

--- a/gme/Spc_Emu.cpp
+++ b/gme/Spc_Emu.cpp
@@ -267,8 +267,6 @@ struct Spc_File : Gme_Info_
 	blargg_err_t load_( Data_Reader& in )
 	{
 		long file_size = in.remain();
-		if ( is_archive )
-			return 0;
 		if ( file_size < Snes_Spc::spc_min_file_size )
 			return gme_wrong_file_type;
 		RETURN_ERR( in.read( &header, head_size ) );

--- a/gme/Spc_Emu.cpp
+++ b/gme/Spc_Emu.cpp
@@ -371,7 +371,7 @@ struct Rsn_File : Spc_File
 
 	Rsn_File() : Spc_File( gme_rsn_type ) { is_archive = true; }
 
-	blargg_err_t load_archive( const char* path )
+	blargg_err_t load_archive_( const char* path )
 	{
 	#ifdef RARDLL
 		set_track_count( rsn_unpack( path, xid6, spc, true ) );
@@ -519,7 +519,7 @@ blargg_err_t Spc_Emu::play_( long count, sample_t* out )
 	return 0;
 }
 
-blargg_err_t Rsn_Emu::load_archive( const char* path )
+blargg_err_t Rsn_Emu::load_archive_( const char* path )
 {
 #ifdef RARDLL
 	set_track_count( rsn_unpack( path, rsn, spc ) );

--- a/gme/Spc_Emu.h
+++ b/gme/Spc_Emu.h
@@ -85,7 +85,7 @@ class Rsn_Emu : public Spc_Emu {
 public:
 	Rsn_Emu() : Spc_Emu( gme_rsn_type ) { is_archive = true; }
 	~Rsn_Emu();
-	blargg_err_t load_archive( const char* );
+	blargg_err_t load_archive_( const char* );
 	header_t const& header( int track ) const { return *(header_t const*) spc[track]; }
 	byte const* trailer( int ) const; // use track_info()
 	long trailer_size( int ) const;

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -59,7 +59,7 @@ gme_type_t const* gme_type_list()
 	#endif
 	#ifdef USE_GME_SPC
 	            gme_spc_type,
-				gme_rsn_type,
+	            gme_rsn_type,
 	#endif
 	#ifdef USE_GME_VGM
 	            gme_vgm_type,

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -190,13 +190,16 @@ gme_err_t gme_open_file( const char* path, Music_Emu** out, int sample_rate )
 	Music_Emu* emu = gme_new_emu( file_type, sample_rate );
 	CHECK_ALLOC( emu );
 
-	// optimization: avoids seeking/re-reading header
-	Remaining_Reader rem( header, header_size, &in );
-	gme_err_t err = emu->load( rem );
-	in.close();
-
+	gme_err_t err;
 	if ( emu->is_archive )
 		err = emu->load_archive( path );
+	else
+	{
+		// optimization: avoids seeking/re-reading header
+		Remaining_Reader rem( header, header_size, &in );
+		err = emu->load( rem );
+	}
+	in.close();
 
 	if ( err )
 		delete emu;


### PR DESCRIPTION
#### Spc_Emu.cpp: move RSN logic to `rsn_unpack()`
The previous approach relied too heavily on the rsn file layout being the same for every rsn, whereas this new approach is slightly more flexible. It should now be able to handle non-spc files appearing midway through the unpacking process.

Space is first reserved for the rsn archive in its entirety, then after copying only spc files/headers to the buffer, any excess space is freed.

#### Gme_File.cpp: check if emu is archive in `load_file()`
For the C interface when calling `gme_load_file()`.

#### Gme_File.cpp: add a protected `load_archive_` function
This way, we don't skip over the pre_load/post_load functions.