### PR TITLE
Fix building a static library

### DIFF
--- a/gme/CMakeLists.txt
+++ b/gme/CMakeLists.txt
@@ -188,7 +188,7 @@ endif()
 # On some platforms we may need to change headers or whatnot based on whether
 # we're building the library or merely using the library. The following is
 # only defined when building the library to allow us to tell which is which.
-set_property(TARGET gme PROPERTY DEFINE_SYMBOL BLARGG_BUILD_DLL)
+target_compile_definitions(gme PRIVATE BLARGG_BUILD_DLL)
 
 target_compile_definitions(gme PRIVATE GEN_TYPES_H)
 if(WORDS_BIGENDIAN)


### PR DESCRIPTION
DEFINE_SYMBOL definitions are only defined when building a shared library.

Without this, building a static library fails with a ton of "missing debug_printf" errors.