### PR TITLE
Gb_Apu::Gb_Apu(): zero regs to avoid unitialized use in update_volume()

### DIFF
--- a/gme/Gb_Apu.cpp
+++ b/gme/Gb_Apu.cpp
@@ -26,6 +26,8 @@ using std::max;
 
 Gb_Apu::Gb_Apu()
 {
+	memset(regs, 0, sizeof(regs));
+	
 	square1.synth = &square_synth;
 	square2.synth = &square_synth;
 	wave.synth  = &other_synth;


### PR DESCRIPTION
From valgrind output:

```
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x41B3C8D: int const& std::max<int>(int const&, int const&) (stl_algobase.h:222)
==10374==    by 0x41B32C2: Gb_Apu::update_volume() (Gb_Apu.cpp:83)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAE6: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAEF: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BB61: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:367)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BB8B: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:372)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAE6: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAEF: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BB61: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:367)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BB8B: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:372)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B3C75: Gb_Apu::volume(double) (Gb_Apu.h:87)
==10374==    by 0x41B3144: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:51)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAE6: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B342E: Gb_Apu::reset() (Gb_Apu.cpp:121)
==10374==    by 0x41B3152: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:52)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAEF: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AA269: Blip_Synth<12, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B32F2: Gb_Apu::update_volume() (Gb_Apu.cpp:84)
==10374==    by 0x41B342E: Gb_Apu::reset() (Gb_Apu.cpp:121)
==10374==    by 0x41B3152: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:52)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAE6: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B342E: Gb_Apu::reset() (Gb_Apu.cpp:121)
==10374==    by 0x41B3152: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:52)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
==10374== 
==10374== Conditional jump or move depends on uninitialised value(s)
==10374==    at 0x419BAEF: Blip_Synth_::volume_unit(double) (Blip_Buffer.cpp:358)
==10374==    by 0x41AE97D: Blip_Synth<8, 1>::volume(double) (Blip_Buffer.h:192)
==10374==    by 0x41B330C: Gb_Apu::update_volume() (Gb_Apu.cpp:85)
==10374==    by 0x41B342E: Gb_Apu::reset() (Gb_Apu.cpp:121)
==10374==    by 0x41B3152: Gb_Apu::Gb_Apu() (Gb_Apu.cpp:52)
==10374==    by 0x41B5CB1: Gbs_Emu::Gbs_Emu() (Gbs_Emu.cpp:26)
==10374==    by 0x41B5F76: new_gbs_emu() (Gbs_Emu.cpp:100)
==10374==    by 0x41A4A82: gme_internal_new_emu_(gme_type_t_ const*, int, bool) (gme.cpp:227)
==10374==    by 0x41A4BE8: gme_new_emu (gme.cpp:264)
==10374==    by 0x41A48EF: gme_open_file (gme.cpp:190)
==10374==    by 0x804A328: Music_Player::load_file(char const*, bool) (Music_Player.cpp:115)
==10374==    by 0x804AC2A: main (player.cpp:121)
```
