### PR TITLE
guard Ym2612* sources properly

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -100,6 +100,8 @@ LOCAL_SRC_FILES := \
 	gme/Vgm_Emu_Impl.cpp \
 	gme/Ym2413_Emu.cpp \
 	gme/Ym2612_Nuked.cpp \
+	gme/Ym2612_GENS.cpp \
+	gme/Ym2612_MAME.cpp \
 	gme/ext/emu2413.c \
 	gme/ext/panning.c \
 	gme/gme.cpp

--- a/gme/Ym2612_Emu.h
+++ b/gme/Ym2612_Emu.h
@@ -2,17 +2,30 @@
 
 // Game_Music_Emu https://bitbucket.org/mpyne/game-music-emu/
 
+#if !defined(VGM_YM2612_GENS) && !defined(VGM_YM2612_NUKED) && !defined(VGM_YM2612_MAME)
+#define VGM_YM2612_NUKED
+#endif
+
 #ifdef VGM_YM2612_GENS // LGPL v2.1+ license
+# if defined(VGM_YM2612_NUKED) || defined(VGM_YM2612_MAME)
+#   error Only one of VGM_YM2612_GENS, VGM_YM2612_NUKED or VGM_YM2612_MAME can be defined
+# endif
 #include "Ym2612_GENS.h"
 typedef Ym2612_GENS_Emu Ym2612_Emu;
 #endif
 
 #ifdef VGM_YM2612_NUKED // LGPL v2.1+ license
+# if defined(VGM_YM2612_GENS) || defined(VGM_YM2612_MAME)
+#   error Only one of VGM_YM2612_GENS, VGM_YM2612_NUKED or VGM_YM2612_MAME can be defined
+# endif
 #include "Ym2612_Nuked.h"
 typedef Ym2612_Nuked_Emu Ym2612_Emu;
 #endif
 
 #ifdef VGM_YM2612_MAME // GPL v2+ license
+# if defined(VGM_YM2612_GENS) || defined(VGM_YM2612_NUKED)
+#   error Only one of VGM_YM2612_GENS, VGM_YM2612_NUKED or VGM_YM2612_MAME can be defined
+# endif
 #include "Ym2612_MAME.h"
 typedef Ym2612_MAME_Emu Ym2612_Emu;
 #endif

--- a/gme/Ym2612_GENS.cpp
+++ b/gme/Ym2612_GENS.cpp
@@ -2,6 +2,8 @@
 
 // Based on Gens 2.10 ym2612.c
 
+#ifdef VGM_YM2612_GENS
+
 #include "Ym2612_GENS.h"
 
 #include <assert.h>
@@ -1317,3 +1319,5 @@ void Ym2612_GENS_Impl::run( int pair_count, Ym2612_GENS_Emu::sample_t* out )
 }
 
 void Ym2612_GENS_Emu::run( int pair_count, sample_t* out ) { impl->run( pair_count, out ); }
+
+#endif /* VGM_YM2612_GENS */

--- a/gme/Ym2612_MAME.cpp
+++ b/gme/Ym2612_MAME.cpp
@@ -2,6 +2,8 @@
 
 // Based on Mame YM2612 ym2612.c
 
+#ifdef VGM_YM2612_MAME
+
 #include "Ym2612_MAME.h"
 
 /*
@@ -3107,3 +3109,5 @@ void Ym2612_MAME_Emu::run(int pair_count, Ym2612_MAME_Emu::sample_t *out)
 	(void) &Ym2612_MameImpl::TimerBOver; // squelch clang warning, which appears to be from a config choice
 	if ( impl ) Ym2612_MameImpl::ym2612_generate( impl, out, pair_count, 1);
 }
+
+#endif /* VGM_YM2612_MAME */

--- a/gme/Ym2612_Nuked.cpp
+++ b/gme/Ym2612_Nuked.cpp
@@ -2,6 +2,8 @@
 
 // Based on Nuked OPN2 ym3438.c and ym3438.h
 
+#ifdef VGM_YM2612_NUKED
+
 #include "Ym2612_Nuked.h"
 
 /*
@@ -1870,3 +1872,5 @@ void Ym2612_Nuked_Emu::run(int pair_count, Ym2612_Nuked_Emu::sample_t *out)
 	if ( !chip_r ) return;
 	Ym2612_NukedImpl::OPN2_GenerateStreamMix(chip_r, out, pair_count);
 }
+
+#endif /* VGM_YM2612_NUKED */


### PR DESCRIPTION
This helps with standalone makefiles, such as Android.mk
to include all those Ym2612* sources.  Also error out if
more than one VGM_YM2612_??? macro is defined.