### PR TITLE
Allow archive format for all single-track file types.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,8 +21,6 @@ GME_YM2612_EMU=VGM_YM2612_NUKED
 
 # For zlib compressed formats:
 GME_ZLIB=Y
-# For SPC RSN format (requires unrar library):
-GME_UNRAR=N
 
 LOCAL_CFLAGS := -O2 -Wall \
 	-DBLARGG_LITTLE_ENDIAN=1 \
@@ -35,11 +33,6 @@ LOCAL_CFLAGS := -O2 -Wall \
 ifeq ($(GME_ZLIB),Y)
 LOCAL_CFLAGS += -DHAVE_ZLIB_H
 endif
-ifeq ($(GME_UNRAR),Y)
-LOCAL_CFLAGS += -DRARDLL
-#either RAR_HDR_UNRAR_H or RAR_HDR_DLL_HPP
-LOCAL_CFLAGS += -DRAR_HDR_UNRAR_H
-endif
 
 LOCAL_CPPFLAGS := -std=c++11 \
 	-fvisibility-inlines-hidden
@@ -47,9 +40,6 @@ LOCAL_CPPFLAGS := -std=c++11 \
 LOCAL_LDFLAGS := -Wl,-no-undefined
 ifeq ($(GME_ZLIB),Y)
 LOCAL_LDFLAGS += -lz
-endif
-ifeq ($(GME_UNRAR),Y)
-LOCAL_LDFLAGS += -lunrar
 endif
 
 LOCAL_SRC_FILES := \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ option(USE_GME_VGM "Enable Sega VGM/VGZ music emulation" ON)
 
 option(GME_SPC_ISOLATED_ECHO_BUFFER "Enable isolated echo buffer on SPC emulator to allow correct playing of \"dodgy\" SPC files made for various ROM hacks ran on ZSNES" OFF)
 option(GME_ZLIB "Enable GME to support compressed sound formats" ON)
-option(GME_UNRAR "Enable SPC RSN format (optional, requires **non-free** UnRAR library)" OFF)
 
 set(GME_YM2612_EMU "Nuked" CACHE STRING "Which YM2612 emulator to use: \"Nuked\" (LGPLv2.1+), \"MAME\" (GPLv2+), or \"GENS\" (LGPLv2.1+)")
 set(GME_YM2612_EMU_CHOICES "Nuked;MAME;GENS")

--- a/gme/CMakeLists.txt
+++ b/gme/CMakeLists.txt
@@ -45,10 +45,6 @@ if(GME_ZLIB)
     find_package(ZLIB QUIET)
 endif()
 
-if (USE_GME_SPC AND GME_UNRAR)
-    find_package(UNRAR QUIET)
-endif()
-
 # Ay_Apu is very popular around here
 if(USE_GME_AY OR USE_GME_KSS)
     list(APPEND libgme_SRCS
@@ -306,29 +302,6 @@ if(NOT MSVC)
             list(APPEND PC_LIBS -lm) # for libgme.pc
         endif()
     endif()
-endif()
-
-if(USE_GME_SPC AND GME_UNRAR)
-  if(UNRAR_FOUND)
-      message(STATUS "UnRAR library located, the RSN file format will be supported")
-      target_compile_definitions(gme PRIVATE RARDLL)
-      if(RAR_HDR_UNRAR_H)
-          target_compile_definitions(gme PRIVATE RAR_HDR_UNRAR_H)
-      elseif(RAR_HDR_DLL_HPP)
-          target_compile_definitions(gme PRIVATE RAR_HDR_DLL_HPP)
-      endif()
-      target_include_directories(gme PRIVATE ${UNRAR_INCLUDE_DIRS})
-      target_link_libraries(gme PRIVATE ${UNRAR_LIBRARIES})
-      # Is not to be installed though
-      list(APPEND PC_LIBS -lunrar) # for libgme.pc
-      if (NOT WIN32) # POSIX Threading for unRAR
-          target_compile_options(gme PRIVATE -pthread)
-      endif()
-  else()
-      message(STATUS "** UnRAR library not found, disabling support for the RSN file format")
-  endif()
-else()
-  message(STATUS "RSN file format excluded")
 endif()
 
 if(GME_ZLIB)

--- a/gme/Gme_File.h
+++ b/gme/Gme_File.h
@@ -76,6 +76,10 @@ public:
 	// must not free it until you're done with the file.
 	blargg_err_t load_mem( void const* data, long size );
 
+	// Load from multiple files already read into memory.
+	// Should only be used for file types with a fixed track count of 1.
+	blargg_err_t load_tracks( void const* in, long* sizes, int count );
+
 	// Load an m3u playlist. Must be done after loading main music file.
 	blargg_err_t load_m3u( const char* path );
 	blargg_err_t load_m3u( Data_Reader& in );
@@ -127,6 +131,9 @@ protected:
 	void set_type( gme_type_t t )       { type_ = t; }
 	blargg_err_t load_remaining_( void const* header, long header_size, Data_Reader& remaining );
 
+	const byte* track_pos( int i ) { return &file_data[tracks[i]]; }
+	long track_size( int i ) { return tracks[i + 1] - tracks[i]; }
+
 	// Overridable
 	virtual void unload();  // called before loading file and if loading fails
 	virtual blargg_err_t load_( Data_Reader& ); // default loads then calls load_mem_()
@@ -152,6 +159,7 @@ private:
 	M3u_Playlist playlist;
 	char playlist_warning [64];
 	blargg_vector<byte> file_data; // only if loaded into memory using default load
+	blargg_vector<long> tracks;    // file start indexes of `file_data`
 
 	blargg_err_t load_m3u_( blargg_err_t );
 	blargg_err_t post_load( blargg_err_t err );

--- a/gme/Gme_File.h
+++ b/gme/Gme_File.h
@@ -112,9 +112,6 @@ public:
 	// clear it. Passes user_data to cleanup function.
 	void set_user_cleanup( gme_user_cleanup_t func ) { user_cleanup_ = func; }
 
-	bool is_archive = false;
-	virtual blargg_err_t load_archive( const char* ) { return gme_wrong_file_type; }
-
 public:
 	// deprecated
 	int error_count() const; // use warning()

--- a/gme/Music_Emu.h
+++ b/gme/Music_Emu.h
@@ -149,10 +149,10 @@ protected:
 	virtual blargg_err_t set_sample_rate_( long sample_rate ) = 0;
 	virtual void set_equalizer_( equalizer_t const& ) { }
 	virtual void enable_accuracy_( bool /* enable */ ) { }
-	virtual void mute_voices_( int mask ) = 0;
+	virtual void mute_voices_( int mask );
 	virtual void disable_echo_( bool /* disable */);
-	virtual void set_tempo_( double ) = 0;
-	virtual blargg_err_t start_track_( int ) = 0; // tempo is set before this
+	virtual void set_tempo_( double );
+	virtual blargg_err_t start_track_( int ); // tempo is set before this
 	virtual blargg_err_t play_( long count, sample_t* out ) = 0;
 	virtual blargg_err_t skip_( long count );
 protected:

--- a/gme/Music_Emu.h
+++ b/gme/Music_Emu.h
@@ -237,7 +237,12 @@ inline void Music_Emu::enable_accuracy( bool b )    { enable_accuracy_( b ); }
 inline void Music_Emu::set_tempo_( double t )       { tempo_ = t; }
 inline void Music_Emu::remute_voices()              { mute_voices( mute_mask_ ); }
 inline void Music_Emu::ignore_silence( bool b )     { ignore_silence_ = b; }
-inline blargg_err_t Music_Emu::start_track_( int )  { return 0; }
+inline blargg_err_t Music_Emu::start_track_( int track )
+{
+	if ( type()->track_count == 1 )
+		return load_mem_( track_pos( track ), track_size( track ) );
+	return 0;
+}
 
 inline void Music_Emu::set_voice_names( const char* const* names )
 {

--- a/gme/Spc_Emu.h
+++ b/gme/Spc_Emu.h
@@ -55,8 +55,7 @@ public:
 	long trailer_size() const;
 
 public:
-	Spc_Emu( gme_type_t );
-	Spc_Emu() : Spc_Emu( gme_spc_type ) {}
+	Spc_Emu();
 	~Spc_Emu();
 protected:
 	blargg_err_t load_mem_( byte const*, long );
@@ -69,9 +68,9 @@ protected:
 	void disable_echo_( bool disable );
 	void set_tempo_( double );
 	void enable_accuracy_( bool );
+private:
 	byte const* file_data;
 	long        file_size;
-private:
 	Fir_Resampler<24> resampler;
 	SPC_Filter filter;
 	Snes_Spc apu;
@@ -80,21 +79,5 @@ private:
 };
 
 inline void Spc_Emu::disable_surround( bool b ) { apu.disable_surround( b ); }
-
-class Rsn_Emu : public Spc_Emu {
-public:
-	Rsn_Emu() : Spc_Emu( gme_rsn_type ) { is_archive = true; }
-	~Rsn_Emu();
-	blargg_err_t load_archive( const char* );
-	header_t const& header( int track ) const { return *(header_t const*) spc[track]; }
-	byte const* trailer( int ) const; // use track_info()
-	long trailer_size( int ) const;
-protected:
-	blargg_err_t track_info_( track_info_t*, int ) const;
-	blargg_err_t start_track_( int );
-private:
-	blargg_vector<byte> rsn;
-	blargg_vector<byte*> spc;
-};
 
 #endif

--- a/gme/blargg_config.h
+++ b/gme/blargg_config.h
@@ -17,7 +17,6 @@
 	gme_kss_type,\
 	gme_nsf_type,\
 	gme_nsfe_type,\
-	gme_rsn_type,\
 	gme_sap_type,\
 	gme_spc_type,\
 	gme_vgm_type,\

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -183,9 +183,9 @@ gme_err_t gme_open_file( const char* path, Music_Emu** out, int sample_rate )
 		header_size = sizeof header;
 		RETURN_ERR( in.read( header, sizeof header ) );
 		file_type = gme_identify_extension( gme_identify_header( header ) );
+		if ( !file_type )
+			return gme_wrong_file_type;
 	}
-	if ( !file_type )
-		return gme_wrong_file_type;
 
 	Music_Emu* emu = gme_new_emu( file_type, sample_rate );
 	CHECK_ALLOC( emu );

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -59,7 +59,6 @@ gme_type_t const* gme_type_list()
 	#endif
 	#ifdef USE_GME_SPC
 	            gme_spc_type,
-				gme_rsn_type,
 	#endif
 	#ifdef USE_GME_VGM
 	            gme_vgm_type,
@@ -86,7 +85,6 @@ const char* gme_identify_header( void const* header )
 		case BLARGG_4CHAR('N','S','F','E'):  return "NSFE";
 		case BLARGG_4CHAR('S','A','P',0x0D): return "SAP";
 		case BLARGG_4CHAR('S','N','E','S'):  return "SPC";
-		case BLARGG_4CHAR('R','a','r','!'):  return "RSN";
 		case BLARGG_4CHAR('V','g','m',' '):  return "VGM";
 	}
 	if (get_be16(header) == BLARGG_2CHAR(0x1F, 0x8B))
@@ -194,9 +192,6 @@ gme_err_t gme_open_file( const char* path, Music_Emu** out, int sample_rate )
 	Remaining_Reader rem( header, header_size, &in );
 	gme_err_t err = emu->load( rem );
 	in.close();
-
-	if ( emu->is_archive )
-		err = emu->load_archive( path );
 
 	if ( err )
 		delete emu;

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -278,6 +278,12 @@ gme_err_t gme_load_tracks( Music_Emu* me, void const* data, long* sizes, int cou
 	return me->load_tracks( data, sizes, count );
 }
 
+int gme_fixed_track_count( gme_type_t t )
+{
+	assert( t );
+	return t->track_count;
+}
+
 gme_err_t gme_load_custom( Music_Emu* me, gme_reader_t func, long size, void* data )
 {
 	Callback_Reader in( func, size, data );

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -273,6 +273,11 @@ gme_err_t gme_load_data( Music_Emu* me, void const* data, long size )
 	return me->load( in );
 }
 
+gme_err_t gme_load_tracks( Music_Emu* me, void const* data, long* sizes, int count )
+{
+	return me->load_tracks( data, sizes, count );
+}
+
 gme_err_t gme_load_custom( Music_Emu* me, gme_reader_t func, long size, void* data )
 {
 	Callback_Reader in( func, size, data );

--- a/gme/gme.exports
+++ b/gme/gme.exports
@@ -61,3 +61,4 @@ gme_vgz_type
 gme_disable_echo
 gme_set_fade_msecs
 gme_load_tracks
+gme_fixed_track_count

--- a/gme/gme.exports
+++ b/gme/gme.exports
@@ -60,4 +60,3 @@ gme_vgm_type
 gme_vgz_type
 gme_disable_echo
 gme_set_fade_msecs
-gme_rsn_type

--- a/gme/gme.exports
+++ b/gme/gme.exports
@@ -60,3 +60,4 @@ gme_vgm_type
 gme_vgz_type
 gme_disable_echo
 gme_set_fade_msecs
+gme_load_tracks

--- a/gme/gme.h
+++ b/gme/gme.h
@@ -292,6 +292,11 @@ BLARGG_EXPORT gme_err_t gme_load_data( Music_Emu*, void const* data, long size )
 BLARGG_EXPORT gme_err_t gme_load_tracks( Music_Emu* me,
                                          void const* data, long* sizes, int count );
 
+/* Return the fixed track count of an emu file type
+ * @since 0.6.4
+ */
+BLARGG_EXPORT int gme_fixed_track_count( gme_type_t );
+
 /* Load music file using custom data reader function that will be called to
 read file data. Most emulators load the entire file in one read call. */
 typedef gme_err_t (*gme_reader_t)( void* your_data, void* out, int count );

--- a/gme/gme.h
+++ b/gme/gme.h
@@ -219,7 +219,6 @@ extern BLARGG_EXPORT const gme_type_t
 	gme_nsfe_type,
 	gme_sap_type,
 	gme_spc_type,
-	gme_rsn_type,
 	gme_vgm_type,
 	gme_vgz_type;
 

--- a/gme/gme.h
+++ b/gme/gme.h
@@ -286,6 +286,12 @@ BLARGG_EXPORT gme_err_t gme_load_file( Music_Emu*, const char path [] );
 /* Load music file from memory into emulator. Makes a copy of data passed. */
 BLARGG_EXPORT gme_err_t gme_load_data( Music_Emu*, void const* data, long size );
 
+/* Load multiple single-track music files from memory into emulator.
+ * @since 0.6.4
+ */
+BLARGG_EXPORT gme_err_t gme_load_tracks( Music_Emu* me,
+                                         void const* data, long* sizes, int count );
+
 /* Load music file using custom data reader function that will be called to
 read file data. Most emulators load the entire file in one read call. */
 typedef gme_err_t (*gme_reader_t)( void* your_data, void* out, int count );

--- a/player/Archive_Reader.cpp
+++ b/player/Archive_Reader.cpp
@@ -1,0 +1,58 @@
+#include "Archive_Reader.h"
+
+#ifdef RARDLL
+
+#include <string.h>
+
+static int CALLBACK call_rar( UINT msg, LPARAM UserData, LPARAM P1, LPARAM P2 )
+{
+	uint8_t **bp = (uint8_t **)UserData;
+	uint8_t *addr = (uint8_t *)P1;
+	memcpy( *bp, addr, P2 );
+	*bp += P2;
+	(void) msg;
+	return 0;
+}
+
+blargg_err_t Rar_Reader::restart( RAROpenArchiveData* data )
+{
+	if ( rar )
+		close();
+	rar = RAROpenArchive( data );
+	if ( !rar )
+		return "Failed to instantiate RAR handle";
+	RARSetCallback( rar, call_rar, (LPARAM)&bp );
+	return nullptr;
+}
+
+blargg_err_t Rar_Reader::open( const char* path, bool skip )
+{
+	blargg_err_t err;
+	RAROpenArchiveData data;
+	memset( &data, 0, sizeof data );
+	data.ArcName = (char *)path;
+
+	// determine space needed for the unpacked size and file count.
+	data.OpenMode = RAR_OM_LIST;
+	if ( (err = restart( &data )) )
+		return err;
+	while ( RARReadHeader( rar, &head ) == ERAR_SUCCESS )
+	{
+		RARProcessFile( rar, RAR_SKIP, nullptr, nullptr );
+		count_++, size_ += head.UnpSize;
+	}
+
+	// prepare for extraction
+	data.OpenMode = skip ? RAR_OM_LIST : RAR_OM_EXTRACT;
+	return restart( &data );
+}
+
+blargg_err_t Rar_Reader::read( void* p )
+{
+	bp = p;
+	if ( RARProcessFile( rar, -1, nullptr, nullptr ) != ERAR_SUCCESS )
+		return "Error processing RAR file";
+	return nullptr;
+}
+
+#endif // RARDLL

--- a/player/Archive_Reader.h
+++ b/player/Archive_Reader.h
@@ -1,0 +1,64 @@
+#include "blargg_common.h"
+
+class Archive_Reader {
+protected:
+	int count_;
+	long size_;
+public:
+	Archive_Reader() : count_( 0 ), size_( 0L ) { }
+	int count() const { return count_; }
+	long size() const { return size_; }
+public:
+	virtual blargg_err_t open( const char* path, bool skip = false ) = 0;
+	virtual blargg_err_t read( void* ) = 0;
+
+	virtual const char* entry_name() const = 0;
+	virtual long entry_size() const = 0;
+	virtual bool next_entry() = 0;
+	virtual void close() { }
+	virtual ~Archive_Reader() { }
+};
+
+#ifdef RARDLL
+
+#ifndef _WIN32
+# define PASCAL
+# define CALLBACK
+# define UINT unsigned int
+# define LONG long
+# define HANDLE void *
+# define LPARAM intptr_t
+#else
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+#endif
+
+#if defined RAR_HDR_UNRAR_H
+# include <unrar.h>
+#elif defined RAR_HDR_DLL_HPP
+# include <dll.hpp>
+#endif
+
+#ifndef ERAR_SUCCESS
+# define ERAR_SUCCESS 0
+#endif
+
+class Rar_Reader : public Archive_Reader {
+	RARHeaderData head;
+	void* rar = nullptr;
+	void* bp = nullptr;
+	blargg_err_t restart( RAROpenArchiveData* );
+public:
+	blargg_err_t open( const char* path, bool skip );
+	blargg_err_t read( void* );
+
+	const char* entry_name() const { return head.FileName; }
+	long entry_size() const { return head.UnpSize; }
+	bool next_entry() { return RARReadHeader( rar, &head ) == ERAR_SUCCESS; }
+	void close() { RARCloseArchive( rar ); rar = nullptr; }
+	~Rar_Reader() { close(); }
+};
+
+#endif // RARDLL

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -1,9 +1,18 @@
+option(GME_UNRAR "Enable RAR file format (optional, requires UnRAR library)" ON)
+
 find_package(SDL2)
+
+if (GME_UNRAR)
+    find_package(UNRAR QUIET)
+endif()
+
 
 set(player_SRCS Audio_Scope.cpp
                 Audio_Scope.h
                 Music_Player.cpp
                 Music_Player.h
+                Archive_Reader.cpp
+                Archive_Reader.h
                 player.cpp)
 
 if(SDL2_FOUND)
@@ -18,6 +27,30 @@ if(SDL2_FOUND)
     set_property(TARGET gme_player PROPERTY CXX_STANDARD 11)
     target_link_libraries(gme_player PRIVATE ${SDL2_LIBRARIES} gme::gme)
     # Is not to be installed though
+
+    if(GME_UNRAR)
+      if(UNRAR_FOUND)
+          message(STATUS "UnRAR library located, player demo will support the RAR file format")
+          target_compile_definitions(gme_player PRIVATE RARDLL)
+          if(RAR_HDR_UNRAR_H)
+              target_compile_definitions(gme_player PRIVATE RAR_HDR_UNRAR_H)
+          elseif(RAR_HDR_DLL_HPP)
+              target_compile_definitions(gme_player PRIVATE RAR_HDR_DLL_HPP)
+          endif()
+          target_include_directories(gme_player PRIVATE ${UNRAR_INCLUDE_DIRS})
+          target_link_libraries(gme_player PRIVATE ${UNRAR_LIBRARIES})
+          # Is not to be installed though
+          list(APPEND PC_LIBS -lunrar) # for libgme.pc
+          if (NOT WIN32) # POSIX Threading for unRAR
+              target_compile_options(gme_player PRIVATE -pthread)
+          endif()
+      else()
+          message(STATUS "** UnRAR library not found, player demo will not support the RAR file format")
+      endif()
+    else()
+      message(STATUS "RAR file format excluded")
+    endif()
+
 else()
     message(STATUS "** SDL library not found, disabling player demo build")
 endif()

--- a/player/Music_Player.cpp
+++ b/player/Music_Player.cpp
@@ -136,13 +136,13 @@ gme_err_t Music_Player::start_track( int track )
 {
 	if ( emu_ )
 	{
-		gme_free_info( track_info_ );
-		track_info_ = NULL;
-		RETURN_ERR( gme_track_info( emu_, &track_info_, track ) );
-	
 		// Sound must not be running when operating on emulator
 		sound_stop();
 		RETURN_ERR( gme_start_track( emu_, track ) );
+		
+		gme_free_info( track_info_ );
+		track_info_ = nullptr;
+		RETURN_ERR( gme_track_info( emu_, &track_info_, track ) );
 		
 		// Calculate track length
 		if ( track_info_->length <= 0 )

--- a/player/Music_Player.cpp
+++ b/player/Music_Player.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "SDL_rwops.h"
+#include "Archive_Reader.h"
 
 /* Copyright (C) 2005-2010 by Shay Green. Permission is hereby granted, free of
 charge, to any person obtaining a copy of this software module and associated
@@ -41,6 +42,22 @@ static void sound_start();
 static void sound_stop();
 static void sound_cleanup();
 
+struct arc_type_t {
+	long header;
+	Archive_Reader* (*new_arc)();
+};
+
+#ifdef RARDLL
+static Archive_Reader* new_rar_reader() { return BLARGG_NEW Rar_Reader; }
+#endif
+
+const arc_type_t arcs[] = {
+#ifdef RARDLL
+	{ BLARGG_4CHAR('R','a','r','!'), &new_rar_reader },
+#endif
+	{ 0, nullptr }
+};
+
 Music_Player::Music_Player()
 {
 	emu_        = 0;
@@ -73,6 +90,23 @@ Music_Player::~Music_Player()
 	stop();
 	sound_cleanup();
 	gme_free_info( track_info_ );
+}
+
+// check if file is an archive
+const arc_type_t* identify_archive( const char* path )
+{
+	long header;
+	char h[4];
+	FILE *in = fopen( path, "rb" );
+	if ( !in )
+		return nullptr;
+	fread( h, 1, sizeof h, in );
+	fclose( in );
+	header = BLARGG_4CHAR( h[0], h[1], h[2], h[3] );
+	for ( const arc_type_t* arc = arcs; arc->header; arc++ )
+		if ( arc->header == header )
+			return arc;
+	return nullptr;
 }
 
 gme_err_t Music_Player::load_file(const char* path , bool by_mem)
@@ -112,7 +146,47 @@ gme_err_t Music_Player::load_file(const char* path , bool by_mem)
 	{
 		printf( "Loading file %s by file path...\n", path );
 		fflush( stdout );
-		RETURN_ERR( gme_open_file( path, &emu_, sample_rate ) );
+
+		const arc_type_t* arc = identify_archive( path );
+		if ( arc )
+		{
+			Archive_Reader* ptr = arc->new_arc();
+			if ( !ptr )
+				return "Failed to create archive reader";
+			Archive_Reader& in = *ptr;
+			blargg_vector<long> sizes;
+			blargg_vector<uint8_t> buf;
+			RETURN_ERR( in.open( path ) );
+			RETURN_ERR( sizes.resize( in.count() ) );
+			RETURN_ERR( buf.resize( in.size() ) );
+
+			int n = 0;
+			uint8_t *bp = buf.begin();
+			gme_type_t emu_type = nullptr;
+			while( in.next_entry() )
+			{ // copy data and file sizes
+				gme_type_t t;
+				RETURN_ERR( in.read( bp ) );
+				if ( (t = gme_identify_extension( in.entry_name() ))
+				&& gme_fixed_track_count( t ) == 1 )
+				{
+					if ( !emu_type )
+						emu_type = t;
+					if ( t == emu_type )
+						bp += (sizes[n++] = in.entry_size());
+				}
+			}
+			delete ptr;
+
+			if ( !emu_type )
+				return gme_wrong_file_type;
+			emu_ = gme_new_emu( emu_type, sample_rate );
+			if ( !emu_ )
+				return "Out of memory";
+			RETURN_ERR( gme_load_tracks( emu_, buf.begin(), sizes.begin(), n ) );
+		}
+		else
+			RETURN_ERR( gme_open_file( path, &emu_, sample_rate ) );
 	}
 	
 	char m3u_path [256 + 5];


### PR DESCRIPTION
Rather than having RAR archives reserved specifically for SPC/RSN files, archives are now open to any single-track, or listable, file types. The archive's contents are scanned and an emulator is made for the first listable file type found.

Support has been implemented for RAR and ZIP. Both are optional, with RAR support being enabled with the presence of the UnRAR library, and ZIP support being enabled with the presence of the LibArchive library.