### PR TITLE
MSVC warning fixes

### DIFF
--- a/gme/Music_Emu.cpp
+++ b/gme/Music_Emu.cpp
@@ -396,7 +396,7 @@ blargg_err_t Music_Emu::play( long out_count, sample_t* out )
 		{
 			// during a run of silence, run emulator at >=2x speed so it gets ahead
 			long ahead_time = silence_lookahead * (out_time + out_count - silence_time) + silence_time;
-			while ( emu_time < ahead_time && !(buf_remain | emu_track_ended_) )
+			while ( emu_time < ahead_time && !(buf_remain | static_cast<long>(emu_track_ended_)) )
 				fill_buf();
 			
 			// fill with silence

--- a/gme/Sap_Emu.cpp
+++ b/gme/Sap_Emu.cpp
@@ -259,7 +259,7 @@ blargg_err_t Sap_Emu::load_mem_( byte const* in, long size )
 	
 	set_warning( info.warning );
 	set_track_count( info.track_count );
-	set_voice_count( Sap_Apu::osc_count << info.stereo );
+	set_voice_count( Sap_Apu::osc_count << static_cast<int>(info.stereo) );
 	apu_impl.volume( gain() );
 	
 	return setup_buffer( 1773447 );

--- a/gme/blargg_common.h
+++ b/gme/blargg_common.h
@@ -72,7 +72,8 @@ public:
 	#define BLARGG_DISABLE_NOTHROW \
 		void* operator new ( size_t s ) noexcept { return malloc( s ); }\
 		void* operator new ( size_t s, const std::nothrow_t& ) noexcept { return malloc( s ); }\
-		void operator delete ( void* p ) noexcept { free( p ); }
+		void operator delete ( void* p ) noexcept { free( p ); }\
+		void operator delete ( void* p, const std::nothrow_t&) noexcept { free( p ); }
 #endif
 
 // Use to force disable exceptions for a specific allocation no matter what class


### PR DESCRIPTION
This fixes (silences) MSVC warnings C4291, C4805 and C4804.
See individual commit messages for details. Also see MSVC CI build
logs from master branch.

There is one warning left, C4146, occurring at 8 places. Don't know
what to do about them, don't know whether or not to do anything about
them.
```
Ay_Apu.cpp(302,22): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Ay_Cpu.cpp(1044,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Hes_Apu.cpp(109,28): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Hes_Apu.cpp(112,50): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Kss_Cpu.cpp(1082,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Sap_Apu.cpp(33,27): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Spc_Dsp.cpp(158,19): warning C4146: unary minus operator applied to unsigned type, result still unsigned
Sms_Apu.cpp(144,26): warning C4146: unary minus operator applied to unsigned type, result still unsigned
```
