### PR TITLE
fix -Wcalloc-transposed-args warning from gcc14

### DIFF
--- a/gme/ext/emu2413.c
+++ b/gme/ext/emu2413.c
@@ -1000,7 +1000,7 @@ OPLL_new (e_uint32 clk, e_uint32 rate)
 
   maketables (clk, rate);
 
-  opll = (OPLL *) calloc (sizeof (OPLL), 1);
+  opll = (OPLL *) calloc (1, sizeof (OPLL));
   if (opll == NULL)
     return NULL;
 


### PR DESCRIPTION
Fixes this warning from new gcc-14:

```
/tmp/libgme/gme/ext/emu2413.c: In function 'OPLL_new':
/tmp/libgme/gme/ext/emu2413.c:1003:35: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1003 |   opll = (OPLL *) calloc (sizeof (OPLL), 1);
      |                                   ^~~~
/tmp/libgme/gme/ext/emu2413.c:1003:35: note: earlier argument should specify number of elements, later size of each element
```
