### PR TITLE
Android.mk: remove 'exceptions' from LOCAL_CPP_FEATURES

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -8,7 +8,6 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := libgme
 
-LOCAL_CPP_FEATURES := exceptions
 #LOCAL_SANITIZE := undefined
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/gme


### PR DESCRIPTION
Not needed since commit bbbe9afb68eeae3c931f3183b91e2fc88847e37f