### PR TITLE
replace blargg_[u]long with [u]int32_t

### DIFF
--- a/gme/Ay_Apu.cpp
+++ b/gme/Ay_Apu.cpp
@@ -171,7 +171,7 @@ void Ay_Apu::run_until( blip_time_t final_end_time )
 	if ( !noise_period )
 		noise_period = noise_period_factor;
 	blip_time_t const old_noise_delay = noise.delay;
-	blargg_ulong const old_noise_lfsr = noise.lfsr;
+	uint32_t const old_noise_lfsr = noise.lfsr;
 
 	// envelope period
 	blip_time_t const env_period_factor = period_factor * 2; // verified
@@ -195,7 +195,7 @@ void Ay_Apu::run_until( blip_time_t final_end_time )
 
 		// period
 		int half_vol = 0;
-		blip_time_t inaudible_period = (blargg_ulong) (osc_output->clock_rate() +
+		blip_time_t inaudible_period = (uint32_t) (osc_output->clock_rate() +
 				inaudible_freq) / (inaudible_freq * 2);
 		if ( osc->period <= inaudible_period && !(osc_mode & tone_off) )
 		{
@@ -237,14 +237,14 @@ void Ay_Apu::run_until( blip_time_t final_end_time )
 		blip_time_t time = start_time + osc->delay;
 		if ( osc_mode & tone_off ) // maintain tone's phase when off
 		{
-			blargg_long count = (final_end_time - time + period - 1) / period;
+			int32_t count = (final_end_time - time + period - 1) / period;
 			time += count * period;
 			osc->phase ^= count & 1;
 		}
 
 		// noise time
 		blip_time_t ntime = final_end_time;
-		blargg_ulong noise_lfsr = 1;
+		uint32_t noise_lfsr = 1;
 		if ( !(osc_mode & noise_off) )
 		{
 			ntime = start_time + old_noise_delay;
@@ -311,8 +311,8 @@ void Ay_Apu::run_until( blip_time_t final_end_time )
 					else
 					{
 						// 20 or more noise periods on average for some music
-						blargg_long remain = end - ntime;
-						blargg_long count = remain / noise_period;
+						int32_t remain = end - ntime;
+						int32_t count = remain / noise_period;
 						if ( remain >= 0 )
 							ntime += noise_period + count * noise_period;
 					}
@@ -380,7 +380,7 @@ void Ay_Apu::run_until( blip_time_t final_end_time )
 	blip_time_t remain = final_end_time - last_time - env.delay;
 	if ( remain >= 0 )
 	{
-		blargg_long count = (remain + env_period) / env_period;
+		int32_t count = (remain + env_period) / env_period;
 		env.pos += count;
 		if ( env.pos >= 0 )
 			env.pos = (env.pos & 31) - 32;

--- a/gme/Ay_Apu.h
+++ b/gme/Ay_Apu.h
@@ -54,7 +54,7 @@ private:
 
 	struct {
 		blip_time_t delay;
-		blargg_ulong lfsr;
+		uint32_t lfsr;
 	} noise;
 
 	struct {

--- a/gme/Ay_Cpu.cpp
+++ b/gme/Ay_Cpu.cpp
@@ -462,7 +462,7 @@ possibly_out_of_time:
 	case 0x29: // ADD HL,HL
 		data = R16( opcode, 4, 0x09 );
 	add_hl_data: {
-		blargg_ulong sum = rp.hl + data;
+		uint32_t sum = rp.hl + data;
 		data ^= rp.hl;
 		rp.hl = sum;
 		flags = (flags & (S80 | Z40 | V04)) |
@@ -710,7 +710,7 @@ possibly_out_of_time:
 	}
 
 	case 0x17:{// RLA
-		blargg_ulong temp = (rg.a << 1) | (flags & C01);
+		uint32_t temp = (rg.a << 1) | (flags & C01);
 		flags = (flags & (S80 | Z40 | P04)) |
 				(temp & (F20 | F08)) |
 				(temp >> 8);
@@ -1028,7 +1028,7 @@ possibly_out_of_time:
 		switch ( data )
 		{
 		{
-			blargg_ulong temp;
+			uint32_t temp;
 		case 0x72: // SBC HL,SP
 		case 0x7A: // ADC HL,SP
 			temp = sp;
@@ -1040,7 +1040,7 @@ possibly_out_of_time:
 		case 0x5A: // ADC HL,DE
 		case 0x6A: // ADC HL,HL
 				temp = R16( data >> 3 & 6, 1, 0 );
-			blargg_ulong sum = temp + (flags & C01);
+			uint32_t sum = temp + (flags & C01);
 			flags = ~data >> 2 & N02;
 			if ( flags )
 				sum = uMinus(sum);
@@ -1351,7 +1351,7 @@ possibly_out_of_time:
 		case 0x19: // ADD IXY,DE
 			temp = R16( data, 4, 0x09 );
 		add_ixy_data: {
-			blargg_ulong sum = ixy + temp;
+			uint32_t sum = ixy + temp;
 			temp ^= ixy;
 			ixy = (uint16_t) sum;
 			flags = (flags & (S80 | Z40 | V04)) |

--- a/gme/Ay_Cpu.h
+++ b/gme/Ay_Cpu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_endian.h"
 
-typedef blargg_long cpu_time_t;
+typedef int32_t cpu_time_t;
 
 // must be defined by caller
 void ay_cpu_out( class Ay_Cpu*, cpu_time_t, unsigned addr, int data );

--- a/gme/Ay_Emu.cpp
+++ b/gme/Ay_Emu.cpp
@@ -56,7 +56,7 @@ static byte const* get_data( Ay_Emu::file_t const& file, byte const* ptr, int mi
 	long file_size = file.end - (byte const*) file.header;
 	assert( (unsigned long) pos <= (unsigned long) file_size - 2 );
 	int offset = (int16_t) get_be16( ptr );
-	if ( !offset || blargg_ulong (pos + offset) > blargg_ulong (file_size - min_size) )
+	if ( !offset || uint32_t (pos + offset) > uint32_t (file_size - min_size) )
 		return 0;
 	return ptr + offset;
 }
@@ -209,7 +209,7 @@ blargg_err_t Ay_Emu::start_track_( int track )
 		}
 		check( len );
 		byte const* in = get_data( file, blocks, 0 ); blocks += 2;
-		if ( len > blargg_ulong (file.end - in) )
+		if ( len > uint32_t (file.end - in) )
 		{
 			set_warning( "Missing file data" );
 			len = file.end - in;

--- a/gme/Classic_Emu.cpp
+++ b/gme/Classic_Emu.cpp
@@ -115,7 +115,7 @@ blargg_err_t Classic_Emu::play_( long count, sample_t* out )
 				remute_voices();
 			}
 			int msec = buf->length();
-			blip_time_t clocks_emulated = (blargg_long) msec * clock_rate_ / 1000;
+			blip_time_t clocks_emulated = (int32_t) msec * clock_rate_ / 1000;
 			RETURN_ERR( run_clocks( clocks_emulated, msec ) );
 			assert( clocks_emulated );
 			buf->end_frame( clocks_emulated );

--- a/gme/Classic_Emu.h
+++ b/gme/Classic_Emu.h
@@ -58,9 +58,9 @@ protected:
 	enum { pad_extra = 8 };
 	blargg_vector<byte> rom;
 	long file_size_;
-	blargg_long rom_addr;
-	blargg_long mask;
-	blargg_long size_; // TODO: eliminate
+	int32_t rom_addr;
+	int32_t mask;
+	int32_t size_; // TODO: eliminate
 
 	blargg_err_t load_rom_data_( Data_Reader& in, int header_size, void* header_out,
 			int fill, long pad_size );
@@ -97,7 +97,7 @@ public:
 	byte* unmapped() { return rom.begin(); }
 
 	// Mask address to nearest power of two greater than size()
-	blargg_long mask_addr( blargg_long addr ) const
+	int32_t mask_addr( int32_t addr ) const
 	{
 		#ifdef check
 			check( addr <= mask );
@@ -106,10 +106,10 @@ public:
 	}
 
 	// Pointer to page starting at addr. Returns unmapped() if outside data.
-	byte* at_addr( blargg_long addr )
+	byte* at_addr( int32_t addr )
 	{
-		blargg_ulong offset = mask_addr( addr ) - rom_addr;
-		if ( offset > blargg_ulong (rom.size() - pad_size) )
+		uint32_t offset = mask_addr( addr ) - rom_addr;
+		if ( offset > uint32_t (rom.size() - pad_size) )
 			offset = 0; // unmapped
 		return &rom [offset];
 	}

--- a/gme/Dual_Resampler.cpp
+++ b/gme/Dual_Resampler.cpp
@@ -119,12 +119,12 @@ void Dual_Resampler::mix_samples( Blip_Buffer& blip_buf, dsample_t* out )
 	for ( int n = sample_buf_size >> 1; n--; )
 	{
 		int s = sn.read();
-		blargg_long l = (blargg_long) in [0] * 2 + s;
+		int32_t l = (int32_t) in [0] * 2 + s;
 		if ( (int16_t) l != l )
 			l = 0x7FFF - (l >> 24);
 
 		sn.next( bass );
-		blargg_long r = (blargg_long) in [1] * 2 + s;
+		int32_t r = (int32_t) in [1] * 2 + s;
 		if ( (int16_t) r != r )
 			r = 0x7FFF - (r >> 24);
 

--- a/gme/Effects_Buffer.cpp
+++ b/gme/Effects_Buffer.cpp
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 	#include BLARGG_ENABLE_OPTIMIZER
 #endif
 
-typedef blargg_long fixed_t;
+typedef int32_t fixed_t;
 
 using std::min;
 using std::max;
@@ -362,7 +362,7 @@ long Effects_Buffer::read_samples( blip_sample_t* out, long total_samples )
 	return total_samples * n_channels;
 }
 
-void Effects_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
+void Effects_Buffer::mix_mono( blip_sample_t* out_, int32_t count )
 {
     for(int i=0; i<max_voices; i++)
     {
@@ -371,12 +371,12 @@ void Effects_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
 	BLIP_READER_BEGIN( c, bufs [i*max_buf_count+0] );
 
 	// unrolled loop
-	for ( blargg_long n = count >> 1; n; --n )
+	for ( int32_t n = count >> 1; n; --n )
 	{
-		blargg_long cs0 = BLIP_READER_READ( c );
+		int32_t cs0 = BLIP_READER_READ( c );
 		BLIP_READER_NEXT( c, bass );
 
-		blargg_long cs1 = BLIP_READER_READ( c );
+		int32_t cs1 = BLIP_READER_READ( c );
 		BLIP_READER_NEXT( c, bass );
 
 		if ( (int16_t) cs0 != cs0 )
@@ -403,7 +403,7 @@ void Effects_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
     }
 }
 
-void Effects_Buffer::mix_stereo( blip_sample_t* out_, blargg_long frames )
+void Effects_Buffer::mix_stereo( blip_sample_t* out_, int32_t frames )
 {
     for(int i=0; i<max_voices; i++)
     {
@@ -442,7 +442,7 @@ void Effects_Buffer::mix_stereo( blip_sample_t* out_, blargg_long frames )
     }
 }
 
-void Effects_Buffer::mix_mono_enhanced( blip_sample_t* out_, blargg_long frames )
+void Effects_Buffer::mix_mono_enhanced( blip_sample_t* out_, int32_t frames )
 {
 	for(int i=0; i<max_voices; i++)
 	{
@@ -509,7 +509,7 @@ void Effects_Buffer::mix_mono_enhanced( blip_sample_t* out_, blargg_long frames 
     }
 }
 
-void Effects_Buffer::mix_enhanced( blip_sample_t* out_, blargg_long frames )
+void Effects_Buffer::mix_enhanced( blip_sample_t* out_, int32_t frames )
 {
     for(int i=0; i<max_voices; i++)
     {

--- a/gme/Effects_Buffer.h
+++ b/gme/Effects_Buffer.h
@@ -81,10 +81,10 @@ private:
 		fixed_t reverb_level;
 	} chans;
 
-	void mix_mono( blip_sample_t*, blargg_long );
-	void mix_stereo( blip_sample_t*, blargg_long );
-	void mix_enhanced( blip_sample_t*, blargg_long );
-	void mix_mono_enhanced( blip_sample_t*, blargg_long );
+	void mix_mono( blip_sample_t*, int32_t );
+	void mix_stereo( blip_sample_t*, int32_t );
+	void mix_enhanced( blip_sample_t*, int32_t );
+	void mix_mono_enhanced( blip_sample_t*, int32_t );
 };
 
 #endif

--- a/gme/Fir_Resampler.cpp
+++ b/gme/Fir_Resampler.cpp
@@ -138,9 +138,9 @@ double Fir_Resampler_::time_ratio( double new_factor, double rolloff, double gai
 	return ratio_;
 }
 
-int Fir_Resampler_::input_needed( blargg_long output_count ) const
+int Fir_Resampler_::input_needed( int32_t output_count ) const
 {
-	blargg_long input_count = 0;
+	int32_t input_count = 0;
 
 	unsigned long skip = skip_bits >> imp_phase;
 	int remain = res - imp_phase;
@@ -162,13 +162,13 @@ int Fir_Resampler_::input_needed( blargg_long output_count ) const
 	return input_extra;
 }
 
-int Fir_Resampler_::avail_( blargg_long input_count ) const
+int Fir_Resampler_::avail_( int32_t input_count ) const
 {
 	int cycle_count = input_count / input_per_cycle;
 	int output_count = cycle_count * res * stereo;
 	input_count -= cycle_count * input_per_cycle;
 
-	blargg_ulong skip = skip_bits >> imp_phase;
+	uint32_t skip = skip_bits >> imp_phase;
 	int remain = res - imp_phase;
 	while ( input_count >= 0 )
 	{

--- a/gme/Fir_Resampler.h
+++ b/gme/Fir_Resampler.h
@@ -48,7 +48,7 @@ public:
 // Output
 
 	// Number of extra input samples needed until 'count' output samples are available
-	int input_needed( blargg_long count ) const;
+	int input_needed( int32_t count ) const;
 
 	// Number of output samples available
 	int avail() const { return avail_( write_pos - &buf [width_ * stereo] ); }
@@ -64,14 +64,14 @@ protected:
 	int imp_phase;
 	int const width_;
 	int const write_offset;
-	blargg_ulong skip_bits;
+	uint32_t skip_bits;
 	int step;
 	int input_per_cycle;
 	double ratio_;
 	sample_t* impulses;
 
 	Fir_Resampler_( int width, sample_t* );
-	int avail_( blargg_long input_count ) const;
+	int avail_( int32_t input_count ) const;
 };
 
 // Width is number of points in FIR. Must be even and 4 or more. More points give
@@ -85,7 +85,7 @@ public:
 
 	// Read at most 'count' samples. Returns number of samples actually read.
 	typedef short sample_t;
-	int read( sample_t* out, blargg_long count );
+	int read( sample_t* out, int32_t count );
 };
 
 // End of public interface
@@ -97,12 +97,12 @@ inline void Fir_Resampler_::write( long count )
 }
 
 template<int width>
-int Fir_Resampler<width>::read( sample_t* out_begin, blargg_long count )
+int Fir_Resampler<width>::read( sample_t* out_begin, int32_t count )
 {
 	sample_t* out = out_begin;
 	const sample_t* in = buf.begin();
 	sample_t* end_pos = write_pos;
-	blargg_ulong skip = skip_bits >> imp_phase;
+	uint32_t skip = skip_bits >> imp_phase;
 	sample_t const* imp = impulses [imp_phase];
 	int remain = res - imp_phase;
 	int const step = this->step;
@@ -132,8 +132,8 @@ int Fir_Resampler<width>::read( sample_t* out_begin, blargg_long count )
 			else
 			{
 				// accumulate in extended precision
-				blargg_long l = 0;
-				blargg_long r = 0;
+				int32_t l = 0;
+				int32_t r = 0;
 
 				const sample_t* i = in;
 

--- a/gme/Gb_Cpu.cpp
+++ b/gme/Gb_Cpu.cpp
@@ -49,7 +49,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 
 inline void Gb_Cpu::set_code_page( int i, uint8_t* p )
 {
-	state->code_map [i] = p - PAGE_OFFSET( i * (blargg_long) page_size );
+	state->code_map [i] = p - PAGE_OFFSET( i * (int32_t) page_size );
 }
 
 void Gb_Cpu::reset( void* unmapped )
@@ -90,9 +90,9 @@ static unsigned const n_flag = 0x40;
 static unsigned const h_flag = 0x20;
 static unsigned const c_flag = 0x10;
 
-bool Gb_Cpu::run( blargg_long cycle_count )
+bool Gb_Cpu::run( int32_t cycle_count )
 {
-	state_.remain = blargg_ulong (cycle_count + clocks_per_instr) / clocks_per_instr;
+	state_.remain = uint32_t (cycle_count + clocks_per_instr) / clocks_per_instr;
 	state_t s;
 	this->state = &s;
 	memcpy( &s, &this->state_, sizeof s );
@@ -679,7 +679,7 @@ loop:
 // Add 16-bit
 
 	{
-		blargg_ulong temp; // need more than 16 bits for carry
+		uint32_t temp; // need more than 16 bits for carry
 		unsigned prev;
 
 	case 0xF8: // LD HL,SP+imm

--- a/gme/Gb_Cpu.h
+++ b/gme/Gb_Cpu.h
@@ -52,10 +52,10 @@ public:
 
 	// Run CPU for at least 'count' cycles and return false, or return true if
 	// illegal instruction is encountered.
-	bool run( blargg_long count );
+	bool run( int32_t count );
 
 	// Number of clock cycles remaining for most recent run() call
-	blargg_long remain() const { return state->remain * clocks_per_instr; }
+	int32_t remain() const { return state->remain * clocks_per_instr; }
 
 	// Can read this many bytes past end of a page
 	enum { cpu_padding = 8 };
@@ -71,7 +71,7 @@ private:
 
 	struct state_t {
 		uint8_t* code_map [page_count + 1];
-		blargg_long remain;
+		int32_t remain;
 	};
 	state_t* state; // points to state_ or a local copy within run()
 	state_t state_;

--- a/gme/Gbs_Emu.cpp
+++ b/gme/Gbs_Emu.cpp
@@ -154,7 +154,7 @@ void Gbs_Emu::set_bank( int n )
 		n = 1;
 	}
 
-	blargg_long addr = n * (blargg_long) bank_size;
+	int32_t addr = n * (int32_t) bank_size;
 	if (addr > rom.size())
 	{
 		return;

--- a/gme/Gym_Emu.h
+++ b/gme/Gym_Emu.h
@@ -58,10 +58,10 @@ private:
 	const byte* loop_begin;
 	const byte* pos;
 	const byte* data_end;
-	blargg_long loop_remain; // frames remaining until loop beginning has been located
+	int32_t loop_remain; // frames remaining until loop beginning has been located
 	header_t header_;
 	double fm_sample_rate;
-	blargg_long clocks_per_frame;
+	int32_t clocks_per_frame;
 	void parse_frame();
 
 	// dac (pcm)

--- a/gme/Hes_Apu.cpp
+++ b/gme/Hes_Apu.cpp
@@ -161,7 +161,7 @@ void Hes_Osc::run_until( synth_t& synth_, blip_time_t end_time )
 						//  debug_printf( "Used period 0\n" );
 					}
 					// maintain phase when silent
-					blargg_long count = (end_time - time + period - 1) / period;
+					int32_t count = (end_time - time + period - 1) / period;
 					phase += count; // phase will be masked below
 					time += count * period;
 				}

--- a/gme/Hes_Cpu.cpp
+++ b/gme/Hes_Cpu.cpp
@@ -96,7 +96,7 @@ bool Hes_Cpu::run( hes_time_t end_time )
 	state_t s = this->state_;
 	this->state = &s;
 	// even on x86, using s.time in place of s_time was slower
-	blargg_long s_time = s.time;
+	int32_t s_time = s.time;
 
 	// registers
 	uint_fast16_t pc = r.pc;
@@ -996,7 +996,7 @@ possibly_out_of_time:
 			hes_time_t new_time = end_time_;
 			if ( !(status & st_i) && new_time > irq_time_ )
 				new_time = irq_time_;
-			blargg_long delta = s.base - new_time;
+			int32_t delta = s.base - new_time;
 			s.base = new_time;
 			s_time += delta;
 		}
@@ -1064,7 +1064,7 @@ possibly_out_of_time:
 		status &= ~st_i;
 	handle_cli: {
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - irq_time_;
+		int32_t delta = s.base - irq_time_;
 		if ( delta <= 0 )
 		{
 			if ( TIME < irq_time_ )
@@ -1095,7 +1095,7 @@ possibly_out_of_time:
 		status |= st_i;
 	handle_sei: {
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		s.base = end_time_;
 		s_time += delta;
 		if ( s_time < 0 )
@@ -1262,7 +1262,7 @@ interrupt:
 		status |= st_i;
 		this->r.status = status; // update externally-visible I flag
 
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		s.base = end_time_;
 		s_time += delta;
 		goto loop;

--- a/gme/Hes_Cpu.h
+++ b/gme/Hes_Cpu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_common.h"
 
-typedef blargg_long hes_time_t; // clock cycle count
+typedef int32_t hes_time_t; // clock cycle count
 typedef unsigned hes_addr_t; // 16-bit address
 enum { future_hes_time = INT_MAX / 2 + 1 };
 
@@ -73,7 +73,7 @@ private:
 	struct state_t {
 		uint8_t const* code_map [page_count + 1];
 		hes_time_t base;
-		blargg_long time;
+		int32_t time;
 	};
 	state_t* state; // points to state_ or a local copy within run()
 	state_t state_;

--- a/gme/Hes_Emu.cpp
+++ b/gme/Hes_Emu.cpp
@@ -498,7 +498,7 @@ int Hes_Emu::cpu_done()
 	return 0;
 }
 
-static void adjust_time( blargg_long& time, hes_time_t delta )
+static void adjust_time( int32_t& time, hes_time_t delta )
 {
 	if ( time < future_hes_time )
 	{

--- a/gme/Hes_Emu.h
+++ b/gme/Hes_Emu.h
@@ -62,8 +62,8 @@ private:
 
 	struct {
 		hes_time_t last_time;
-		blargg_long count;
-		blargg_long load;
+		int32_t count;
+		int32_t load;
 		int raw_load;
 		byte enabled;
 		byte fired;

--- a/gme/Kss_Cpu.cpp
+++ b/gme/Kss_Cpu.cpp
@@ -80,7 +80,7 @@ Kss_Cpu::Kss_Cpu()
 
 inline void Kss_Cpu::set_page( int i, void* write, void const* read )
 {
-	blargg_long offset = KSS_CPU_PAGE_OFFSET( i * (blargg_long) page_size );
+	int32_t offset = KSS_CPU_PAGE_OFFSET( i * (int32_t) page_size );
 	state->write [i] = (byte      *) write - offset;
 	state->read  [i] = (byte const*) read  - offset;
 }
@@ -99,7 +99,7 @@ void Kss_Cpu::reset( void* unmapped_write, void const* unmapped_read )
 	memset( &r, 0, sizeof r );
 }
 
-void Kss_Cpu::map_mem( unsigned addr, blargg_ulong size, void* write, void const* read )
+void Kss_Cpu::map_mem( unsigned addr, uint32_t size, void* write, void const* read )
 {
 	// address range must begin and end on page boundaries
 	require( addr % page_size == 0 );
@@ -108,7 +108,7 @@ void Kss_Cpu::map_mem( unsigned addr, blargg_ulong size, void* write, void const
 	unsigned first_page = addr / page_size;
 	for ( unsigned i = size / page_size; i--; )
 	{
-		blargg_long offset = i * (blargg_long) page_size;
+		int32_t offset = i * (int32_t) page_size;
 		set_page( first_page + i, (byte*) write + offset, (byte const*) read + offset );
 	}
 }
@@ -496,7 +496,7 @@ possibly_out_of_time:
 	case 0x29: // ADD HL,HL
 		data = R16( opcode, 4, 0x09 );
 	add_hl_data: {
-		blargg_ulong sum = rp.hl + data;
+		uint32_t sum = rp.hl + data;
 		data ^= rp.hl;
 		rp.hl = sum;
 		flags = (flags & (S80 | Z40 | V04)) |
@@ -744,7 +744,7 @@ possibly_out_of_time:
 	}
 
 	case 0x17:{// RLA
-		blargg_ulong temp = (rg.a << 1) | (flags & C01);
+		uint32_t temp = (rg.a << 1) | (flags & C01);
 		flags = (flags & (S80 | Z40 | P04)) |
 				(temp & (F20 | F08)) |
 				(temp >> 8);
@@ -1065,7 +1065,7 @@ possibly_out_of_time:
 		switch ( data )
 		{
 		{
-			blargg_ulong temp;
+			uint32_t temp;
 		case 0x72: // SBC HL,SP
 		case 0x7A: // ADC HL,SP
 			temp = sp;
@@ -1077,7 +1077,7 @@ possibly_out_of_time:
 		case 0x5A: // ADC HL,DE
 		case 0x6A: // ADC HL,HL
 				temp = R16( data >> 3 & 6, 1, 0 );
-			blargg_ulong sum = temp + (flags & C01);
+			uint32_t sum = temp + (flags & C01);
 			flags = ~data >> 2 & N02;
 			if ( flags )
 				sum = uMinus(sum);
@@ -1388,7 +1388,7 @@ possibly_out_of_time:
 		case 0x19: // ADD IXY,DE
 			temp = R16( data, 4, 0x09 );
 		    add_ixy_data: {
-			blargg_ulong sum = ixy + temp;
+			uint32_t sum = ixy + temp;
 			temp ^= ixy;
 			ixy = (uint16_t) sum;
 			flags = (flags & (S80 | Z40 | V04)) |

--- a/gme/Kss_Cpu.h
+++ b/gme/Kss_Cpu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_endian.h"
 
-typedef blargg_long cpu_time_t;
+typedef int32_t cpu_time_t;
 
 // must be defined by caller
 void kss_cpu_out( class Kss_Cpu*, cpu_time_t, unsigned addr, int data );
@@ -20,7 +20,7 @@ public:
 
 	// Map memory. Start and size must be multiple of page_size.
 	static const unsigned int page_size = 0x2000;
-	void map_mem( unsigned addr, blargg_ulong size, void* write, void const* read );
+	void map_mem( unsigned addr, uint32_t size, void* write, void const* read );
 
 	// Map address to page
 	uint8_t* write( unsigned addr );

--- a/gme/Kss_Emu.cpp
+++ b/gme/Kss_Emu.cpp
@@ -226,7 +226,7 @@ blargg_err_t Kss_Emu::start_track_( int track )
 	rom.set_addr( -load_size - header_.extra_header );
 
 	// check available bank data
-	blargg_long const bank_size = this->bank_size();
+	int32_t const bank_size = this->bank_size();
 	int max_banks = (rom.file_size() - load_size + bank_size - 1) / bank_size;
 	bank_count = header_.bank_mode & 0x7F;
 	if ( bank_count > max_banks )
@@ -276,7 +276,7 @@ void Kss_Emu::set_bank( int logical, int physical )
 	}
 	else
 	{
-		long phys = physical * (blargg_long) bank_size;
+		long phys = physical * (int32_t) bank_size;
 		for ( unsigned offset = 0; offset < bank_size; offset += page_size )
 			cpu::map_mem( addr + offset, page_size,
 					unmapped_write, rom.at_addr( phys + offset ) );

--- a/gme/Kss_Emu.h
+++ b/gme/Kss_Emu.h
@@ -70,7 +70,7 @@ private:
 	unsigned scc_enabled; // 0 or 0xC000
 	int bank_count;
 	void set_bank( int logical, int physical );
-	blargg_long bank_size() const { return (16 * 1024L) >> (header_.bank_mode >> 7 & 1); }
+	int32_t bank_size() const { return (16 * 1024L) >> (header_.bank_mode >> 7 & 1); }
 
 	blip_time_t play_period;
 	blip_time_t next_play;

--- a/gme/Kss_Scc_Apu.cpp
+++ b/gme/Kss_Scc_Apu.cpp
@@ -37,7 +37,7 @@ void Scc_Apu::run_until( blip_time_t end_time )
 		int volume = 0;
 		if ( regs [0x8F] & (1 << index) )
 		{
-			blip_time_t inaudible_period = (blargg_ulong) (output->clock_rate() +
+			blip_time_t inaudible_period = (uint32_t) (output->clock_rate() +
 					inaudible_freq * 32) / (inaudible_freq * 16);
 			if ( period > inaudible_period )
 				volume = (regs [0x8A + index] & 0x0F) * (amp_range / 256 / 15);
@@ -62,7 +62,7 @@ void Scc_Apu::run_until( blip_time_t end_time )
 			if ( !volume )
 			{
 				// maintain phase
-				blargg_long count = (end_time - time + period - 1) / period;
+				int32_t count = (end_time - time + period - 1) / period;
 				osc.phase = (osc.phase + count) & (wave_size - 1);
 				time += count * period;
 			}

--- a/gme/Multi_Buffer.cpp
+++ b/gme/Multi_Buffer.cpp
@@ -148,7 +148,7 @@ long Stereo_Buffer::read_samples( blip_sample_t* out, long count )
 	return count * 2;
 }
 
-void Stereo_Buffer::mix_stereo( blip_sample_t* out_, blargg_long count )
+void Stereo_Buffer::mix_stereo( blip_sample_t* out_, int32_t count )
 {
 	blip_sample_t* BLIP_RESTRICT out = out_;
 	int const bass = BLIP_READER_BASS( bufs [1] );
@@ -159,8 +159,8 @@ void Stereo_Buffer::mix_stereo( blip_sample_t* out_, blargg_long count )
 	for ( ; count; --count )
 	{
 		int c = BLIP_READER_READ( center );
-		blargg_long l = c + BLIP_READER_READ( left );
-		blargg_long r = c + BLIP_READER_READ( right );
+		int32_t l = c + BLIP_READER_READ( left );
+		int32_t r = c + BLIP_READER_READ( right );
 		if ( (int16_t) l != l )
 			l = 0x7FFF - (l >> 24);
 
@@ -181,7 +181,7 @@ void Stereo_Buffer::mix_stereo( blip_sample_t* out_, blargg_long count )
 	BLIP_READER_END( left, bufs [1] );
 }
 
-void Stereo_Buffer::mix_stereo_no_center( blip_sample_t* out_, blargg_long count )
+void Stereo_Buffer::mix_stereo_no_center( blip_sample_t* out_, int32_t count )
 {
 	blip_sample_t* BLIP_RESTRICT out = out_;
 	int const bass = BLIP_READER_BASS( bufs [1] );
@@ -190,11 +190,11 @@ void Stereo_Buffer::mix_stereo_no_center( blip_sample_t* out_, blargg_long count
 
 	for ( ; count; --count )
 	{
-		blargg_long l = BLIP_READER_READ( left );
+		int32_t l = BLIP_READER_READ( left );
 		if ( (int16_t) l != l )
 			l = 0x7FFF - (l >> 24);
 
-		blargg_long r = BLIP_READER_READ( right );
+		int32_t r = BLIP_READER_READ( right );
 		if ( (int16_t) r != r )
 			r = 0x7FFF - (r >> 24);
 
@@ -210,7 +210,7 @@ void Stereo_Buffer::mix_stereo_no_center( blip_sample_t* out_, blargg_long count
 	BLIP_READER_END( left, bufs [1] );
 }
 
-void Stereo_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
+void Stereo_Buffer::mix_mono( blip_sample_t* out_, int32_t count )
 {
 	blip_sample_t* BLIP_RESTRICT out = out_;
 	int const bass = BLIP_READER_BASS( bufs [0] );
@@ -218,7 +218,7 @@ void Stereo_Buffer::mix_mono( blip_sample_t* out_, blargg_long count )
 
 	for ( ; count; --count )
 	{
-		blargg_long s = BLIP_READER_READ( center );
+		int32_t s = BLIP_READER_READ( center );
 		if ( (int16_t) s != s )
 			s = 0x7FFF - (s >> 24);
 

--- a/gme/Multi_Buffer.h
+++ b/gme/Multi_Buffer.h
@@ -116,9 +116,9 @@ private:
 	int stereo_added;
 	int was_stereo;
 
-	void mix_stereo_no_center( blip_sample_t*, blargg_long );
-	void mix_stereo( blip_sample_t*, blargg_long );
-	void mix_mono( blip_sample_t*, blargg_long );
+	void mix_stereo_no_center( blip_sample_t*, int32_t );
+	void mix_stereo( blip_sample_t*, int32_t );
+	void mix_mono( blip_sample_t*, int32_t );
 };
 
 // Silent_Buffer generates no samples, useful where no sound is wanted

--- a/gme/Music_Emu.cpp
+++ b/gme/Music_Emu.cpp
@@ -210,9 +210,9 @@ void Music_Emu::set_autoload_playback_limit( bool do_autoload_limit )
 
 // Tell/Seek
 
-blargg_long Music_Emu::msec_to_samples( blargg_long msec ) const
+int32_t Music_Emu::msec_to_samples( int32_t msec ) const
 {
-	blargg_long sec = msec / 1000;
+	int32_t sec = msec / 1000;
 	msec -= sec * 1000;
 	return (sec * sample_rate() + msec * sample_rate() / 1000) * out_channels();
 }
@@ -224,8 +224,8 @@ long Music_Emu::tell_samples() const
 
 long Music_Emu::tell() const
 {
-	blargg_long rate = sample_rate() * out_channels();
-	blargg_long sec = out_time / rate;
+	int32_t rate = sample_rate() * out_channels();
+	int32_t sec = out_time / rate;
 	return sec * 1000 + (out_time - sec * rate) * 1000 / rate;
 }
 
@@ -307,7 +307,7 @@ void Music_Emu::set_fade( long start_msec, long length_msec )
 }
 
 // unit / pow( 2.0, (double) x / step )
-static int int_log( blargg_long x, int step, int unit )
+static int int_log( int32_t x, int step, int unit )
 {
 	int shift = x / step;
 	int fraction = (x - shift * step) * unit / step;

--- a/gme/Music_Emu.h
+++ b/gme/Music_Emu.h
@@ -174,12 +174,12 @@ private:
 	int out_channels() const { return this->multi_channel() ? 2*8 : 2; }
 
 	long sample_rate_;
-	blargg_long msec_to_samples( blargg_long msec ) const;
+	int32_t msec_to_samples( int32_t msec ) const;
 
 	// track-specific
 	int current_track_;
-	blargg_long out_time;  // number of samples played since start of track
-	blargg_long emu_time;  // number of samples emulator has generated since start of track
+	int32_t out_time;  // number of samples played since start of track
+	int32_t emu_time;  // number of samples emulator has generated since start of track
 	bool emu_track_ended_; // emulator has reached end of track
 	bool emu_autoload_playback_limit_; // whether to load and obey track length by default
 	volatile bool track_ended_;
@@ -187,7 +187,7 @@ private:
 	void end_track_if_error( blargg_err_t );
 
 	// fading
-	blargg_long fade_start;
+	int32_t fade_start;
 	int fade_step;
 	void handle_fade( long count, sample_t* out );
 

--- a/gme/Nes_Apu.h
+++ b/gme/Nes_Apu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_common.h"
 
-typedef blargg_long nes_time_t; // CPU clock cycle count
+typedef int32_t nes_time_t; // CPU clock cycle count
 typedef unsigned nes_addr_t; // 16-bit memory address
 
 #include "Nes_Oscs.h"

--- a/gme/Nes_Cpu.cpp
+++ b/gme/Nes_Cpu.cpp
@@ -851,7 +851,7 @@ imm##op:
 		SET_STATUS( temp );
 		if ( !((data ^ status) & st_i) ) goto loop; // I flag didn't change
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - irq_time_;
+		int32_t delta = s.base - irq_time_;
 		if ( delta <= 0 ) goto loop;
 		if ( status & st_i ) goto loop;
 		s_time += delta;
@@ -920,7 +920,7 @@ imm##op:
 	handle_cli: {
 		//debug_printf( "CLI at %d\n", TIME );
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - irq_time_;
+		int32_t delta = s.base - irq_time_;
 		if ( delta <= 0 )
 		{
 			if ( TIME < irq_time_ )
@@ -951,7 +951,7 @@ imm##op:
 		status |= st_i;
 	handle_sei: {
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		s.base = end_time_;
 		s_time += delta;
 		if ( s_time < 0 )
@@ -1034,7 +1034,7 @@ interrupt:
 		WRITE_LOW( sp, temp );
 
 		this->r.status = status |= st_i;
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		if ( delta >= 0 ) goto loop;
 		s_time += delta;
 		s.base = end_time_;

--- a/gme/Nes_Cpu.h
+++ b/gme/Nes_Cpu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_common.h"
 
-typedef blargg_long nes_time_t; // clock cycle count
+typedef int32_t nes_time_t; // clock cycle count
 typedef unsigned nes_addr_t; // 16-bit address
 enum { future_nes_time = INT_MAX / 2 + 1 };
 

--- a/gme/Nes_Fme7_Apu.cpp
+++ b/gme/Nes_Fme7_Apu.cpp
@@ -109,7 +109,7 @@ void Nes_Fme7_Apu::run_until( blip_time_t end_time )
 				// maintain phase when silent
 				int count = (end_time - time + period - 1) / period;
 				phases [index] ^= count & 1;
-				time += (blargg_long) count * period;
+				time += (int32_t) count * period;
 			}
 		}
 

--- a/gme/Nes_Namco_Apu.cpp
+++ b/gme/Nes_Namco_Apu.cpp
@@ -98,7 +98,7 @@ void Nes_Namco_Apu::run_until( blip_time_t nes_end_time )
 			if ( !volume )
 				continue;
 
-			blargg_long freq = (osc_reg [4] & 3) * 0x10000 + osc_reg [2] * 0x100L + osc_reg [0];
+			int32_t freq = (osc_reg [4] & 3) * 0x10000 + osc_reg [2] * 0x100L + osc_reg [0];
 			if ( freq < 64 * active_oscs )
 				continue; // prevent low frequencies from excessively delaying freq changes
 			blip_resampled_time_t period =

--- a/gme/Nes_Namco_Apu.h
+++ b/gme/Nes_Namco_Apu.h
@@ -42,7 +42,7 @@ private:
 	Nes_Namco_Apu& operator = ( const Nes_Namco_Apu& );
 
 	struct Namco_Osc {
-		blargg_long delay;
+		int32_t delay;
 		Blip_Buffer* output;
 		short last_amp;
 		short wave_pos;

--- a/gme/Nes_Oscs.cpp
+++ b/gme/Nes_Oscs.cpp
@@ -87,7 +87,7 @@ inline nes_time_t Nes_Square::maintain_phase( nes_time_t time, nes_time_t end_ti
 	{
 		int count = (remain + timer_period - 1) / timer_period;
 		phase = (phase + count) & (phase_range - 1);
-		time += (blargg_long) count * timer_period;
+		time += (int32_t) count * timer_period;
 	}
 	return time;
 }
@@ -196,7 +196,7 @@ inline nes_time_t Nes_Triangle::maintain_phase( nes_time_t time, nes_time_t end_
 		int count = (remain + timer_period - 1) / timer_period;
 		phase = ((unsigned) phase + 1 - count) & (phase_range * 2 - 1);
 		phase++;
-		time += (blargg_long) count * timer_period;
+		time += (int32_t) count * timer_period;
 	}
 	return time;
 }

--- a/gme/Nsfe_Emu.cpp
+++ b/gme/Nsfe_Emu.cpp
@@ -136,8 +136,8 @@ blargg_err_t Nsfe_Info::load( Data_Reader& in, Nsf_Emu* nsf_emu )
 		// read size and tag
 		byte block_header [2] [4];
 		RETURN_ERR( in.read( block_header, sizeof block_header ) );
-		blargg_long size = get_le32( block_header [0] );
-		blargg_long tag  = get_le32( block_header [1] );
+		int32_t size = get_le32( block_header [0] );
+		int32_t tag  = get_le32( block_header [1] );
 
 		if ( size < 0 )
 			return "Corrupt file";
@@ -155,7 +155,7 @@ blargg_err_t Nsfe_Info::load( Data_Reader& in, Nsf_Emu* nsf_emu )
 				finfo.track_count = 1;
 				finfo.first_track = 0;
 
-				RETURN_ERR( in.read( &finfo, min( size, (blargg_long) nsfe_info_size ) ) );
+				RETURN_ERR( in.read( &finfo, min( size, (int32_t) nsfe_info_size ) ) );
 				if ( size > nsfe_info_size )
 					RETURN_ERR( in.skip( size - nsfe_info_size ) );
 				phase = 1;

--- a/gme/Sap_Apu.cpp
+++ b/gme/Sap_Apu.cpp
@@ -19,9 +19,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 
 static int const max_frequency = 12000; // pure waves above this frequency are silenced
 
-static void gen_poly( blargg_ulong mask, int count, byte* out )
+static void gen_poly( uint32_t mask, int count, byte* out )
 {
-	blargg_ulong n = 1;
+	uint32_t n = 1;
 	do
 	{
 		int bits = 0;
@@ -40,10 +40,10 @@ static void gen_poly( blargg_ulong mask, int count, byte* out )
 
 // poly5
 static int const poly5_len = (1 <<  5) - 1;
-static blargg_ulong const poly5_mask = (1UL << poly5_len) - 1;
-static blargg_ulong const poly5 = 0x167C6EA1;
+static uint32_t const poly5_mask = (1UL << poly5_len) - 1;
+static uint32_t const poly5 = 0x167C6EA1;
 
-static inline blargg_ulong run_poly5( blargg_ulong in, int shift )
+static inline uint32_t run_poly5( uint32_t in, int shift )
 {
 	return (in << shift & poly5_mask) | (in >> (poly5_len - shift));
 }
@@ -61,9 +61,9 @@ Sap_Apu_Impl::Sap_Apu_Impl()
 	{
 		byte poly5 [4];
 		gen_poly( POLY_MASK(  5, 2, 0 ), sizeof poly5,  poly5  );
-		blargg_ulong n = poly5 [3] * 0x1000000L + poly5 [2] * 0x10000L +
+		uint32_t n = poly5 [3] * 0x1000000L + poly5 [2] * 0x10000L +
 				poly5 [1] * 0x100L + poly5 [0];
-		blargg_ulong rev = n & 1;
+		uint32_t rev = n & 1;
 		for ( int i = 1; i < poly5_len; i++ )
 			rev |= (n >> i & 1) << (poly5_len - i);
 		debug_printf( "poly5: 0x%08lX\n", rev );
@@ -102,7 +102,7 @@ inline void Sap_Apu::calc_periods()
 		osc_t* const osc = &oscs [i];
 
 		int const osc_reload = osc->regs [0]; // cache
-		blargg_long period = (osc_reload + 1) * divider;
+		int32_t period = (osc_reload + 1) * divider;
 		static byte const fast_bits [osc_count] = { 1 << 6, 1 << 4, 1 << 5, 1 << 3 };
 		if ( this->control & fast_bits [i] )
 		{
@@ -208,7 +208,7 @@ void Sap_Apu::run_until( blip_time_t end_time )
 					poly_inc -= poly_len; // allows more optimized inner loop below
 
 					// square/poly5 wave
-					blargg_ulong wave = poly5;
+					uint32_t wave = poly5;
 					check( poly5 & 1 ); // low bit is set for pure wave
 					int poly5_inc = 0;
 					if ( !(osc_control & 0x80) )
@@ -281,7 +281,7 @@ void Sap_Apu::run_until( blip_time_t end_time )
 		blip_time_t remain = end_time - time;
 		if ( remain > 0 )
 		{
-			blargg_long count = (remain + period - 1) / period;
+			int32_t count = (remain + period - 1) / period;
 			osc->phase ^= count;
 			time += count * period;
 		}

--- a/gme/Sap_Cpu.cpp
+++ b/gme/Sap_Cpu.cpp
@@ -799,7 +799,7 @@ imm##op:
 			sap_time_t new_time = end_time_;
 			if ( !(status & st_i) && new_time > irq_time_ )
 				new_time = irq_time_;
-			blargg_long delta = s.base - new_time;
+			int32_t delta = s.base - new_time;
 			s.base = new_time;
 			s_time += delta;
 		}
@@ -864,7 +864,7 @@ imm##op:
 		status &= ~st_i;
 	handle_cli: {
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - irq_time_;
+		int32_t delta = s.base - irq_time_;
 		if ( delta <= 0 )
 		{
 			if ( TIME < irq_time_ )
@@ -895,7 +895,7 @@ imm##op:
 		status |= st_i;
 	handle_sei: {
 		this->r.status = status; // update externally-visible I flag
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		s.base = end_time_;
 		s_time += delta;
 		if ( s_time < 0 )
@@ -962,7 +962,7 @@ interrupt:
 		status |= st_i;
 		this->r.status = status; // update externally-visible I flag
 
-		blargg_long delta = s.base - end_time_;
+		int32_t delta = s.base - end_time_;
 		s.base = end_time_;
 		s_time += delta;
 		goto loop;

--- a/gme/Sap_Cpu.h
+++ b/gme/Sap_Cpu.h
@@ -6,7 +6,7 @@
 
 #include "blargg_common.h"
 
-typedef blargg_long sap_time_t; // clock cycle count
+typedef int32_t sap_time_t; // clock cycle count
 typedef unsigned sap_addr_t; // 16-bit address
 enum { future_sap_time = INT_MAX / 2 + 1 };
 

--- a/gme/blargg_common.h
+++ b/gme/blargg_common.h
@@ -90,20 +90,6 @@ public:
 #define BLARGG_2CHAR( a, b ) \
 	((a&0xFF)*0x100L + (b&0xFF))
 
-// blargg_long/blargg_ulong = at least 32 bits, int if it's big enough
-
-#if INT_MAX < 0x7FFFFFFF || LONG_MAX == 0x7FFFFFFF
-	typedef long blargg_long;
-#else
-	typedef int blargg_long;
-#endif
-
-#if UINT_MAX < 0xFFFFFFFF || ULONG_MAX == 0xFFFFFFFF
-	typedef unsigned long blargg_ulong;
-#else
-	typedef unsigned blargg_ulong;
-#endif
-
 // int8_t etc.
 #include <stdint.h>
 

--- a/gme/blargg_endian.h
+++ b/gme/blargg_endian.h
@@ -52,20 +52,20 @@ inline unsigned get_be16( void const* p )
 			(unsigned) ((unsigned char const*) p) [1];
 }
 
-inline blargg_ulong get_le32( void const* p )
+inline uint32_t get_le32( void const* p )
 {
-	return  (blargg_ulong) ((unsigned char const*) p) [3] << 24 |
-			(blargg_ulong) ((unsigned char const*) p) [2] << 16 |
-			(blargg_ulong) ((unsigned char const*) p) [1] <<  8 |
-			(blargg_ulong) ((unsigned char const*) p) [0];
+	return  (uint32_t) ((unsigned char const*) p) [3] << 24 |
+			(uint32_t) ((unsigned char const*) p) [2] << 16 |
+			(uint32_t) ((unsigned char const*) p) [1] <<  8 |
+			(uint32_t) ((unsigned char const*) p) [0];
 }
 
-inline blargg_ulong get_be32( void const* p )
+inline uint32_t get_be32( void const* p )
 {
-	return  (blargg_ulong) ((unsigned char const*) p) [0] << 24 |
-			(blargg_ulong) ((unsigned char const*) p) [1] << 16 |
-			(blargg_ulong) ((unsigned char const*) p) [2] <<  8 |
-			(blargg_ulong) ((unsigned char const*) p) [3];
+	return  (uint32_t) ((unsigned char const*) p) [0] << 24 |
+			(uint32_t) ((unsigned char const*) p) [1] << 16 |
+			(uint32_t) ((unsigned char const*) p) [2] <<  8 |
+			(uint32_t) ((unsigned char const*) p) [3];
 }
 
 inline void set_le16( void* p, unsigned n )
@@ -80,7 +80,7 @@ inline void set_be16( void* p, unsigned n )
 	((unsigned char*) p) [1] = (unsigned char) n;
 }
 
-inline void set_le32( void* p, blargg_ulong n )
+inline void set_le32( void* p, uint32_t n )
 {
 	((unsigned char*) p) [0] = (unsigned char) n;
 	((unsigned char*) p) [1] = (unsigned char) (n >> 8);
@@ -88,7 +88,7 @@ inline void set_le32( void* p, blargg_ulong n )
 	((unsigned char*) p) [3] = (unsigned char) (n >> 24);
 }
 
-inline void set_be32( void* p, blargg_ulong n )
+inline void set_be32( void* p, uint32_t n )
 {
 	((unsigned char*) p) [3] = (unsigned char) n;
 	((unsigned char*) p) [2] = (unsigned char) (n >> 8);
@@ -148,13 +148,13 @@ inline void set_be32( void* p, blargg_ulong n )
 
 // auto-selecting versions
 
-inline void set_le( uint16_t* p, unsigned     n ) { SET_LE16( p, n ); }
-inline void set_le( uint32_t* p, blargg_ulong n ) { SET_LE32( p, n ); }
-inline void set_be( uint16_t* p, unsigned     n ) { SET_BE16( p, n ); }
-inline void set_be( uint32_t* p, blargg_ulong n ) { SET_BE32( p, n ); }
-inline unsigned     get_le( uint16_t* p ) { return GET_LE16( p ); }
-inline blargg_ulong get_le( uint32_t* p ) { return GET_LE32( p ); }
-inline unsigned     get_be( uint16_t* p ) { return GET_BE16( p ); }
-inline blargg_ulong get_be( uint32_t* p ) { return GET_BE32( p ); }
+inline void set_le( uint16_t* p, unsigned n ) { SET_LE16( p, n ); }
+inline void set_le( uint32_t* p, uint32_t n ) { SET_LE32( p, n ); }
+inline void set_be( uint16_t* p, unsigned n ) { SET_BE16( p, n ); }
+inline void set_be( uint32_t* p, uint32_t n ) { SET_BE32( p, n ); }
+inline unsigned get_le( uint16_t* p ) { return GET_LE16( p ); }
+inline uint32_t get_le( uint32_t* p ) { return GET_LE32( p ); }
+inline unsigned get_be( uint16_t* p ) { return GET_BE16( p ); }
+inline uint32_t get_be( uint32_t* p ) { return GET_BE32( p ); }
 
 #endif

--- a/gme/hes_cpu_io.h
+++ b/gme/hes_cpu_io.h
@@ -27,7 +27,7 @@ inline byte const* Hes_Emu::cpu_set_mmr( int page, int bank )
 {
 	write_pages [page] = 0;
 	if ( bank < 0x80 )
-		return rom.at_addr( bank * (blargg_long) page_size );
+		return rom.at_addr( bank * (int32_t) page_size );
 
 	byte* data = 0;
 	switch ( bank )

--- a/gme/nes_cpu_io.h
+++ b/gme/nes_cpu_io.h
@@ -82,7 +82,7 @@ void Nsf_Emu::cpu_write( nes_addr_t addr, int data )
 	unsigned bank = addr - bank_select_addr;
 	if ( bank < bank_count )
 	{
-		blargg_long offset = rom.mask_addr( data * (blargg_long) bank_size );
+		int32_t offset = rom.mask_addr( data * (int32_t) bank_size );
 		if ( offset >= rom.size() )
 			set_warning( "Invalid bank" );
 		cpu::map_code( (bank + 8) * bank_size, bank_size, rom.at_addr( offset ) );


### PR DESCRIPTION
@Wohlstand: The `blargg_long` and `blargg_ulong` types are obviously
poor man's `int32_t` and `uint32_t`, therefore I replaced them as such.

However, there are many places where `long` type is used explicitly:
I am not 100% sure whether or not that their intention is actually
`int32_t`, at least not for all of them yet. Do you know why `long` is
used? Can you contact the original author for it? Do you want me to
replace them too?

