### PR TITLE
Fix header install path for non UNIX OS's

### DIFF
--- a/gme/CMakeLists.txt
+++ b/gme/CMakeLists.txt
@@ -468,5 +468,5 @@ unset(TMP_PC_LIBS)
 
 configure_file(libgme.pc.in libgme.pc @ONLY)
 
-install(FILES ${EXPORTED_HEADERS} DESTINATION include/gme)
+install(FILES ${EXPORTED_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gme)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgme.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
For Haiku headers are installed in /boot/system/develop/headers, which equals to CMAKE_INSTALL_INCLUDEDIR