### PR TITLE
don't detect track end if ignore_silence is on

### DIFF
--- a/gme/Music_Emu.cpp
+++ b/gme/Music_Emu.cpp
@@ -423,7 +423,7 @@ blargg_err_t Music_Emu::play( long out_count, sample_t* out )
 			memset( out, 0, pos * sizeof *out );
 			silence_count -= pos;
 
-			if ( emu_time - silence_time > silence_max * out_channels() * sample_rate() )
+			if ( !ignore_silence_ && emu_time - silence_time > silence_max * out_channels() * sample_rate() )
 			{
 				track_ended_  = emu_track_ended_ = true;
 				silence_count = 0;


### PR DESCRIPTION
Hi there!

I'm using libgme by way of [spct](https://codeberg.org/jneen/spct) and trying to render stems - each channel separately. I'm doing this by rendering with certain channels muted, but it seems like there was an oversight with regard to `ignore_silence` - Music_Emu.cpp will still end the track early if 6 seconds of silence is detected.

This patch allows for arbitrary runs of silence if `ignore_silence` has been set.