### PR TITLE
cmake: do not force C++ standart to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # CMake project definition file.
-cmake_minimum_required(VERSION 3.3...3.10)
+
+cmake_minimum_required(VERSION 3.8...4.0)
 project(libgme)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -63,10 +64,6 @@ option(GME_BUILD_FRAMEWORK "Build framework instead of dylib on macOS" ${BUILD_F
 option(GME_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer error-checking" ${ENABLE_UBSAN})
 option(GME_BUILD_TESTING "Build demo tests" ${BUILD_TESTING})
 option(GME_BUILD_EXAMPLES "Add example project build rules" ${GME_IS_ROOT})
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 test_big_endian(WORDS_BIGENDIAN)
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -5,9 +5,10 @@
 include_directories(${CMAKE_SOURCE_DIR}/gme ${CMAKE_SOURCE_DIR})
 link_directories(${CMAKE_BINARY_DIR}/gme)
 
-set (CMAKE_C_STANDARD 99)
-
 add_executable(demo Wave_Writer.cpp basics.c)
+if ("c_std_99" IN_LIST CMAKE_C_COMPILE_FEATURES)
+    target_compile_features(demo PRIVATE c_std_99)
+endif()
 
 # Add command to copy build file over.
 add_custom_command(TARGET demo
@@ -21,6 +22,9 @@ target_link_libraries(demo gme::gme)
 
 
 add_executable(demo_mem Wave_Writer.cpp basics_mem.c)
+if ("c_std_99" IN_LIST CMAKE_C_COMPILE_FEATURES)
+    target_compile_features(demo_mem PRIVATE c_std_99)
+endif()
 
 add_custom_command(TARGET demo_mem
     POST_BUILD
@@ -32,12 +36,14 @@ target_link_libraries(demo_mem gme::gme)
 
 
 add_executable(demo_multi Wave_Writer.cpp basics_multi.c)
+if ("c_std_99" IN_LIST CMAKE_C_COMPILE_FEATURES)
+    target_compile_features(demo_multi PRIVATE c_std_99)
+endif()
 target_link_libraries(demo_multi gme::gme)
 
 #
 # Testing
 #
-
 if(GME_BUILD_TESTING)
     add_test(NAME sanity_test_NSF
         COMMAND demo)

--- a/gme/CMakeLists.txt
+++ b/gme/CMakeLists.txt
@@ -367,6 +367,9 @@ endmacro()
 # Building the Shared version of GME
 if(GME_BUILD_SHARED)
     add_library(gme_shared SHARED ${libgme_SRCS})
+    if ("cxx_std_11" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        target_compile_features(gme_shared PRIVATE cxx_std_11)
+    endif()
     set_target_properties(gme_shared PROPERTIES OUTPUT_NAME gme)
 
     if(WIN32)
@@ -413,6 +416,9 @@ endif()
 if(GME_BUILD_STATIC)
     # Static build.
     add_library(gme_static STATIC ${libgme_SRCS})
+    if ("cxx_std_11" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        target_compile_features(gme_static PRIVATE cxx_std_11)
+    endif()
 
     # Static builds need to find static zlib (and static forms of other needed
     # libraries.  Ensure CMake looks only for static libs if we're doing a static

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -19,6 +19,9 @@ if(SDL2_FOUND)
     message(STATUS "SDL2 library located, player demo is available to be built in the /player directory")
 
     add_executable(gme_player ${player_SRCS})
+    if ("cxx_std_11" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        target_compile_features(gme_player PRIVATE cxx_std_11)
+    endif()
     target_include_directories(gme_player PRIVATE
         ${SDL2_INCLUDE_DIRS}
         ${PROJECT_SOURCE_DIR}/gme


### PR DESCRIPTION
Compiler may set a higher standart by default, defer to that, instead.
Same for C standart under demos directory
