### PR TITLE
kss: distinguish between Sega systems

### DIFF
--- a/gme/Kss_Emu.cpp
+++ b/gme/Kss_Emu.cpp
@@ -64,6 +64,9 @@ static void copy_kss_fields( Kss_Emu::header_t const& h, track_info_t* out )
 		system = "Sega Master System";
 		if ( h.device_flags & 0x04 )
 			system = "Game Gear";
+
+		if ( h.device_flags & 0x01 )
+			system = "Sega Mega Drive";
 	}
 	Gme_File::copy_field_( out->system, system );
 }


### PR DESCRIPTION
Sega Master System is equipped with an SN76489 PSG chip, the Mega Drive additionally includes an YM2612

inspired by kode54's code https://github.com/kode54/Game_Music_Emu/blob/master/gme/Kss_Emu.cpp