### PR TITLE
vgm: convert metadata strings from UCS-2 to UTF-8

### DIFF
--- a/gme/Gme_File.cpp
+++ b/gme/Gme_File.cpp
@@ -206,6 +206,7 @@ blargg_err_t Gme_File::track_info( track_info_t* out, int track ) const
 	out->fade_length   = -1;
 	out->play_length   = -1;
 	out->repeat_count  = -1;
+	out->isUtf8        = 0;
 	out->song [0]      = 0;
 
 	out->game [0]      = 0;

--- a/gme/Gme_File.h
+++ b/gme/Gme_File.h
@@ -39,6 +39,8 @@ struct track_info_t
 	 * otherwise a default of 150000 (2.5 minutes) */
 	long play_length;
 
+	long isUtf8;
+
 	/* empty string if not available */
 	char system    [256];
 	char game      [256];

--- a/gme/Nsfe_Emu.cpp
+++ b/gme/Nsfe_Emu.cpp
@@ -258,6 +258,7 @@ blargg_err_t Nsfe_Info::track_info_( track_info_t* out, int track ) const
 	GME_COPY_FIELD( info, out, author );
 	GME_COPY_FIELD( info, out, copyright );
 	GME_COPY_FIELD( info, out, dumper );
+	out->isUtf8 = 1;
 	return 0;
 }
 

--- a/gme/Sap_Emu.cpp
+++ b/gme/Sap_Emu.cpp
@@ -208,6 +208,7 @@ static void copy_sap_fields( Sap_Emu::info_t const& in, track_info_t* out )
 	Gme_File::copy_field_( out->game,      in.name );
 	Gme_File::copy_field_( out->author,    in.author );
 	Gme_File::copy_field_( out->copyright, in.copyright );
+	out->isUtf8 = 1;
 }
 
 blargg_err_t Sap_Emu::track_info_( track_info_t* out, int ) const

--- a/gme/Vgm_Emu.cpp
+++ b/gme/Vgm_Emu.cpp
@@ -106,6 +106,7 @@ static void parse_gd3( byte const* in, byte const* end, track_info_t* out )
 	in = get_gd3_str ( in, end, out->copyright );
 	in = get_gd3_pair( in, end, out->dumper );
 	in = get_gd3_str ( in, end, out->comment );
+	out->isUtf8 = 1;
 }
 
 static int const gd3_header_size = 12;

--- a/gme/gme.cpp
+++ b/gme/gme.cpp
@@ -326,7 +326,6 @@ gme_err_t gme_track_info( Music_Emu const* me, gme_info_t** out, int track )
 	COPY( loop_length );
 	COPY( fade_length );
 
-	info->i5  = -1;
 	info->i6  = -1;
 	info->i7  = -1;
 	info->i8  = -1;
@@ -336,7 +335,9 @@ gme_err_t gme_track_info( Music_Emu const* me, gme_info_t** out, int track )
 	info->i12 = -1;
 	info->i13 = -1;
 	info->i14 = -1;
-	info->i15 = -1;
+	info->i15  = -1;
+
+	COPY( isUtf8 );
 
 	info->s7  = "";
 	info->s8  = "";

--- a/gme/gme.h
+++ b/gme/gme.h
@@ -145,7 +145,10 @@ struct gme_info_t
 	/* fade length in milliseconds; -1 if unknown */
 	int fade_length;
 
-	int i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15; /* reserved */
+	/* strings encoding, 1 if UTF-8, 0 if unknown ANSI codepage */
+	int isUtf8;
+
+	int i6,i7,i8,i9,i10,i11,i12,i13,i14,i15; /* reserved */
 
 	/* empty string ("") if not available */
 	const char* system;


### PR DESCRIPTION
In [VGM](https://www.smspower.org/Music/VGMFileFormat) files the metadata strings are encoded as UCS-2.
Currently only the low byte is considered and if the high byte is not zero the character is simply replaced by a question mark, causing loss of information.

This patch converts the strings from UCS-2 to UTF-8 preserving the metadata.
The downside is that other formats provide the track info in ANSI or ASCII, thus causing an inconsistent interface.

One possible solution is to add a flag to the `track_info_t` struct that specifies if metadata is in UTF-8 or ANSI format.
Otherwise the applications could rely on the file extension but that would be quite ugly.